### PR TITLE
8271122: Test java/math/BigInteger/LargeValueExceptions.java times out

### DIFF
--- a/test/jdk/java/math/BigInteger/LargeValueExceptions.java
+++ b/test/jdk/java/math/BigInteger/LargeValueExceptions.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8200698
  * @summary Tests that exceptions are thrown for ops which would overflow
- * @requires (sun.arch.data.model == "64" & os.maxMemory >= 4g)
+ * @requires (os.family != "solaris" & sun.arch.data.model == "64" & os.maxMemory >= 4g)
  * @run testng/othervm -Xmx4g LargeValueExceptions
  */
 import java.math.BigInteger;


### PR DESCRIPTION
Please review this JDK 11u request to suppress the test `LargeValueExceptions` on Solaris.