### PR TITLE
8273939: Backport of 8248414 to JDK11 breaks MacroAssembler::adrp

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4242,6 +4242,7 @@ void MacroAssembler::adrp(Register reg1, const Address &dest, uint64_t &byte_off
     uint64_t adrp_target
       = (target & 0xffffffffULL) | ((uint64_t)pc() & 0xffff00000000ULL);
 
+    _adrp(reg1, (address)adrp_target);
     movk(reg1, target >> 32, 32);
   }
   byte_offset = (uint64_t)dest.target() & 0xfff;


### PR DESCRIPTION
This is not a backport. This fixes issue in backport of 8248414.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273939](https://bugs.openjdk.java.net/browse/JDK-8273939): Backport of 8248414 to JDK11 breaks MacroAssembler::adrp


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.java.net/jdk11u pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u/pull/11.diff">https://git.openjdk.java.net/jdk11u/pull/11.diff</a>

</details>
