### PR TITLE
8269850: Most JDK releases report macOS version 12 as 10.16 instead of 12.0

### DIFF
--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -254,6 +254,7 @@ void setOSNameAndVersion(java_props_t *sprops) {
     // Hardcode os_name, and fill in os_version
     sprops->os_name = strdup("Mac OS X");
 
+    NSString *nsVerStr = NULL;
     char* osVersionCStr = NULL;
     // Mac OS 10.9 includes the [NSProcessInfo operatingSystemVersion] function,
     // but it's not in the 10.9 SDK.  So, call it via NSInvocation.
@@ -266,7 +267,6 @@ void setOSNameAndVersion(java_props_t *sprops) {
         [invoke invokeWithTarget:[NSProcessInfo processInfo]];
         [invoke getReturnValue:&osVer];
 
-        NSString *nsVerStr;
         // Copy out the char* if running on version other than 10.16 Mac OS (10.16 == 11.x)
         // or explicitly requesting version compatibility
         if (!((long)osVer.majorVersion == 10 && (long)osVer.minorVersion >= 16) ||
@@ -278,35 +278,29 @@ void setOSNameAndVersion(java_props_t *sprops) {
                 nsVerStr = [NSString stringWithFormat:@"%ld.%ld.%ld",
                         (long)osVer.majorVersion, (long)osVer.minorVersion, (long)osVer.patchVersion];
             }
-            // Copy out the char*
-            osVersionCStr = strdup([nsVerStr UTF8String]);
         } else {
             // Version 10.16, without explicit env setting of SYSTEM_VERSION_COMPAT
-            // AKA 11.x; compute the version number from the letter in the ProductBuildVersion
+            // AKA 11+ Read the *real* ProductVersion from the hidden link to avoid SYSTEM_VERSION_COMPAT
+            // If not found, fallback below to the SystemVersion.plist
             NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile :
-                             @"/System/Library/CoreServices/SystemVersion.plist"];
+                             @"/System/Library/CoreServices/.SystemVersionPlatform.plist"];
             if (version != NULL) {
-                NSString *nsBuildVerStr = [version objectForKey : @"ProductBuildVersion"];
-                if (nsBuildVerStr != NULL && nsBuildVerStr.length >= 3) {
-                    int letter = [nsBuildVerStr characterAtIndex:2];
-                    if (letter >= 'B' && letter <= 'Z') {
-                        int vers = letter - 'A' - 1;
-                        asprintf(&osVersionCStr, "11.%d", vers);
-                    }
-                }
+                nsVerStr = [version objectForKey : @"ProductVersion"];
             }
         }
     }
     // Fallback if running on pre-10.9 Mac OS
-    if (osVersionCStr == NULL) {
+    if (nsVerStr == NULL) {
         NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile :
                                  @"/System/Library/CoreServices/SystemVersion.plist"];
         if (version != NULL) {
-            NSString *nsVerStr = [version objectForKey : @"ProductVersion"];
-            if (nsVerStr != NULL) {
-                osVersionCStr = strdup([nsVerStr UTF8String]);
-            }
+            nsVerStr = [version objectForKey : @"ProductVersion"];
         }
+    }
+
+    if (nsVerStr != NULL) {
+        // Copy out the char*
+        osVersionCStr = strdup([nsVerStr UTF8String]);
     }
     if (osVersionCStr == NULL) {
         osVersionCStr = strdup("Unknown");


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8269850 from the openjdk/jdk repository.

The commit being backported was authored by Roger Riggs on 23 Sep 2021 and was reviewed by Naoto Sato and Christoph Langer.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269850](https://bugs.openjdk.java.net/browse/JDK-8269850): Most JDK releases report macOS version 12 as 10.16 instead of 12.0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.java.net/jdk11u pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u/pull/12.diff">https://git.openjdk.java.net/jdk11u/pull/12.diff</a>

</details>
