### PR TITLE
8276774: Cookie stored in CookieHandler not sent if user headers contain cookie

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Request.java
@@ -108,21 +108,22 @@ class Http1Request {
         final HttpHeaders uh = userHeaders;
 
         // Filter any headers from systemHeaders that are set in userHeaders
-        systemHeaders = HttpHeaders.of(systemHeaders.map(), (k,v) -> uh.firstValue(k).isEmpty());
+        final HttpHeaders sh = HttpHeaders.of(systemHeaders.map(),
+                (k,v) -> uh.firstValue(k).isEmpty());
 
         // If we're sending this request through a tunnel,
         // then don't send any preemptive proxy-* headers that
         // the authentication filter may have saved in its
         // cache.
-        collectHeaders1(sb, systemHeaders, nocookies);
+        collectHeaders1(sb, sh, nocookies);
 
         // If we're sending this request through a tunnel,
         // don't send any user-supplied proxy-* headers
         // to the target server.
-        collectHeaders1(sb, userHeaders, nocookies);
+        collectHeaders1(sb, uh, nocookies);
 
-        // Gather all 'Cookie:' headers and concatenate their
-        // values in a single line.
+        // Gather all 'Cookie:' headers from the unfiltered system headers,
+        // and the user headers, and concatenate their values in a single line
         collectCookies(sb, systemHeaders, userHeaders);
 
         // terminate headers

--- a/test/jdk/java/net/httpclient/UserCookieTest.java
+++ b/test/jdk/java/net/httpclient/UserCookieTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,34 +23,24 @@
 
 /*
  * @test
- * @bug 8199851
- * @summary Test for multiple vs single cookie header for HTTP/2 vs HTTP/1.1
+ * @bug 8276774
+ * @summary Test that user-supplied cookies are appended to
+ *          server-cookies for HTTP/2 vs HTTP/1.1
  * @modules java.base/sun.net.www.http
  *          java.net.http/jdk.internal.net.http.common
  *          java.net.http/jdk.internal.net.http.frame
  *          java.net.http/jdk.internal.net.http.hpack
  *          java.logging
  *          jdk.httpserver
- * @library /lib/testlibrary /test/lib http2/server
+ * @library /test/lib http2/server
  * @build Http2TestServer
- * @build jdk.testlibrary.SimpleSSLContext
+ * @build jdk.test.lib.net.SimpleSSLContext
  * @run testng/othervm
  *       -Djdk.tls.acknowledgeCloseNotify=true
  *       -Djdk.httpclient.HttpClient.log=trace,headers,requests
- *       CookieHeaderTest
+ *       UserCookieTest
  */
 
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsConfigurator;
-import com.sun.net.httpserver.HttpsServer;
-import jdk.testlibrary.SimpleSSLContext;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
-import javax.net.ServerSocketFactory;
-import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -58,7 +48,6 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.net.CookieHandler;
-import java.net.CookieManager;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -72,7 +61,6 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -82,13 +70,23 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.net.ServerSocketFactory;
+import javax.net.ssl.SSLContext;
+
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
+import jdk.test.lib.net.SimpleSSLContext;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import static java.lang.System.out;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
-public class CookieHeaderTest implements HttpServerAdapters {
+public class UserCookieTest implements HttpServerAdapters {
 
     SSLContext sslContext;
     HttpTestServer httpTestServer;        // HTTP/1.1    [ 6 servers ]
@@ -153,9 +151,15 @@ public class CookieHeaderTest implements HttpServerAdapters {
         cookies.add("LOC\u0100TION=TRAIN_STATION");
         cookies.add("ORDER=BISCUITS");
         cookieHeaders.put("Cookie", cookies);
+        String userCookie = "PRICE=42";
+        List<String> expectedCookies =
+                Stream.concat(cookies.stream(), Stream.of(userCookie)).toList();
+
+
 
         HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(uri)
-                .header("X-uuid", "uuid-" + requestCounter.incrementAndGet());
+                .header("X-uuid", "uuid-" + requestCounter.incrementAndGet())
+                .header("Cookie", userCookie);
         if (version != null) {
             requestBuilder.version(version);
         }
@@ -172,11 +176,12 @@ public class CookieHeaderTest implements HttpServerAdapters {
             assertEquals(response.statusCode(), 200);
             assertEquals(response.body(), MESSAGE);
             assertEquals(response.headers().allValues("X-Request-Cookie"),
-                    cookies.stream()
+                    expectedCookies.stream()
                             .filter(s -> !s.startsWith("LOC"))
-                            .collect(Collectors.toList()));
+                            .toList());
             requestBuilder = HttpRequest.newBuilder(uri)
-                    .header("X-uuid", "uuid-" + requestCounter.incrementAndGet());
+                    .header("X-uuid", "uuid-" + requestCounter.incrementAndGet())
+                    .header("Cookie", userCookie);
             if (version != null) {
                 requestBuilder.version(version);
             }
@@ -242,14 +247,14 @@ public class CookieHeaderTest implements HttpServerAdapters {
             this.cookies = map;
         }
 
-        @Override
+        @java.lang.Override
         public Map<String, List<String>> get(URI uri, Map<String, List<String>> requestHeaders)
                 throws IOException
         {
             return cookies;
         }
 
-        @Override
+        @java.lang.Override
         public void put(URI uri, Map<String, List<String>> responseHeaders)
                 throws IOException
         {
@@ -260,7 +265,7 @@ public class CookieHeaderTest implements HttpServerAdapters {
     static class CookieValidationHandler implements HttpTestHandler {
         ConcurrentHashMap<String,String> closedRequests = new ConcurrentHashMap<>();
 
-        @Override
+        @java.lang.Override
         public void handle(HttpTestExchange t) throws IOException {
             System.out.println("CookieValidationHandler for: " + t.getRequestURI());
 
@@ -333,10 +338,15 @@ public class CookieHeaderTest implements HttpServerAdapters {
                     os.write(msg.getBytes(UTF_8));
                 } else if (cookie.size() > 1 && !cookie.get(1).equals("ORDER=BISCUITS")) {
                     String msg = "Incorrect cookie header value:[" + cookie.get(1) + "]";
+                     (new RuntimeException(msg)).printStackTrace();
+                    t.sendResponseHeaders(500, -1);
+                    os.write(msg.getBytes(UTF_8));
+                } else if (cookie.size() > 2 && !cookie.get(2).equals("PRICE=42")) {
+                    String msg = "Incorrect cookie header value:[" + cookie.get(2) + "]";
                     (new RuntimeException(msg)).printStackTrace();
                     t.sendResponseHeaders(500, -1);
                     os.write(msg.getBytes(UTF_8));
-                } else if (cookie.size() != 2) {
+                } else if (cookie.size() != 3) {
                     String msg = "Incorrect cookie header values:[" + cookie + "]";
                     (new RuntimeException(msg)).printStackTrace();
                     t.sendResponseHeaders(500, -1);
@@ -393,7 +403,7 @@ public class CookieHeaderTest implements HttpServerAdapters {
             return b.toString();
         }
 
-        @Override
+        @java.lang.Override
         public void run() {
             try {
                 while(!stopped) {
@@ -470,13 +480,16 @@ public class CookieHeaderTest implements HttpServerAdapters {
                                         .map(String::trim)
                                         .collect(Collectors.toList());
                         Collections.sort(values);
-                        if (values.size() != 2) {
+                        if (values.size() != 3) {
                             resp = "Bad cookie list: " + values;
                             status = "500 Internal Server Error";
                         } else if (!values.get(0).equals("CUSTOMER=ARTHUR_DENT")) {
                             resp = "Unexpected cookie: " + values.get(0) + " in " + values;
                             status = "500 Internal Server Error";
                         } else if (!values.get(1).equals("ORDER=BISCUITS")) {
+                            resp = "Unexpected cookie: " + values.get(1) + " in " + values;
+                            status = "500 Internal Server Error";
+                        } else if (!values.get(2).equals("PRICE=42")) {
                             resp = "Unexpected cookie: " + values.get(1) + " in " + values;
                             status = "500 Internal Server Error";
                         } else {

--- a/test/jdk/java/net/httpclient/UserCookieTest.java
+++ b/test/jdk/java/net/httpclient/UserCookieTest.java
@@ -32,9 +32,9 @@
  *          java.net.http/jdk.internal.net.http.hpack
  *          java.logging
  *          jdk.httpserver
- * @library /test/lib http2/server
+ * @library /lib/testlibrary http2/server
  * @build Http2TestServer
- * @build jdk.test.lib.net.SimpleSSLContext
+ * @build jdk.testlibrary.SimpleSSLContext
  * @run testng/othervm
  *       -Djdk.tls.acknowledgeCloseNotify=true
  *       -Djdk.httpclient.HttpClient.log=trace,headers,requests
@@ -76,7 +76,7 @@ import javax.net.ssl.SSLContext;
 import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
-import jdk.test.lib.net.SimpleSSLContext;
+import jdk.testlibrary.SimpleSSLContext;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
@@ -153,7 +153,7 @@ public class UserCookieTest implements HttpServerAdapters {
         cookieHeaders.put("Cookie", cookies);
         String userCookie = "PRICE=42";
         List<String> expectedCookies =
-                Stream.concat(cookies.stream(), Stream.of(userCookie)).toList();
+                Stream.concat(cookies.stream(), Stream.of(userCookie)).collect(Collectors.toList());
 
 
 
@@ -178,7 +178,7 @@ public class UserCookieTest implements HttpServerAdapters {
             assertEquals(response.headers().allValues("X-Request-Cookie"),
                     expectedCookies.stream()
                             .filter(s -> !s.startsWith("LOC"))
-                            .toList());
+                            .collect(Collectors.toList()));
             requestBuilder = HttpRequest.newBuilder(uri)
                     .header("X-uuid", "uuid-" + requestCounter.incrementAndGet())
                     .header("Cookie", userCookie);


### PR DESCRIPTION
Almost clean Backport of JDK-8276774. One hunk in Stream.java required manual integration because the switch expression doesn't exist in 11u. The test needed adaptations because SimpleSSLContext is located at a different place in 11u and `Stream.toList()` is unavailable (see 2nd commit).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276774](https://bugs.openjdk.java.net/browse/JDK-8276774): Cookie stored in CookieHandler not sent if user headers contain cookie


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.java.net/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.java.net/jdk11u pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u/pull/18.diff">https://git.openjdk.java.net/jdk11u/pull/18.diff</a>

</details>
