### PR TITLE
8251329: (zipfs) Files.walkFileTree walks infinitely if zip has dir named "." inside

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -1102,6 +1102,10 @@ class ZipFileSystem extends FileSystem {
                 zerror("invalid CEN header (bad header size)");
             }
             IndexNode inode = new IndexNode(cen, pos, nlen);
+            if (hasDotOrDotDot(inode.name)) {
+                throw new ZipException("ZIP file can't be opened as a file system " +
+                        "because an entry has a '.' or '..' element in its name");
+            }
             inodes.put(inode, inode);
             if (zc.isUTF8() || (flag & FLAG_USE_UTF8) != 0) {
                 checkUTF8(inode.name);
@@ -1116,6 +1120,44 @@ class ZipFileSystem extends FileSystem {
         }
         buildNodeTree();
         return cen;
+    }
+
+    /**
+     * Check Inode.name to see if it includes a "." or ".." in the name array
+     * @param path  the path as stored in Inode.name to verify
+     * @return true if the path contains a "." or ".." entry; false otherwise
+     */
+    private boolean hasDotOrDotDot(byte[] path) {
+        // Inode.name always includes "/" in path[0]
+        assert path[0] == '/';
+        if (path.length == 1) {
+            return false;
+        }
+        int index = 1;
+        while (index < path.length) {
+            int starting = index;
+            while (index < path.length && path[index] != '/') {
+                index++;
+            }
+            // Check the path snippet for a "." or ".."
+            if (isDotOrDotDotPath(path, starting, index)) {
+                return true;
+            }
+            index++;
+        }
+        return false;
+    }
+
+    /**
+     * Check the path to see if it includes a "." or ".."
+     * @param path  the path to check
+     * @return true if the path contains a "." or ".." entry; false otherwise
+     */
+    private boolean isDotOrDotDotPath(byte[] path, int start, int index) {
+        int pathLen = index - start;
+        if ((pathLen == 1 && path[start] == '.'))
+            return true;
+        return (pathLen == 2 && path[start] == '.') && path[start + 1] == '.';
     }
 
     private  final void checkUTF8(byte[] a) throws ZipException {

--- a/src/jdk.zipfs/share/classes/module-info.java
+++ b/src/jdk.zipfs/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,9 @@
  * The zip file system provider can be created by
  * {@link java.nio.file.FileSystems#newFileSystem
  * FileSystems.newFileSystem} if installed.
+ *
+ * The Zip file system provider does not support opening an existing Zip file
+ * that contains entries with "." or ".." in its name elements.
  *
  * @provides java.nio.file.spi.FileSystemProvider
  * @moduleGraph

--- a/test/jdk/jdk/nio/zipfs/HasDotDotTest.java
+++ b/test/jdk/jdk/nio/zipfs/HasDotDotTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Stream;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+/**
+ * @test
+ * @bug 8251329
+ * @summary Excercise Zip FS with "." or ".." in a Zip Entry name
+ * @modules jdk.zipfs
+ * @run testng/othervm HasDotDotTest
+ */
+public class HasDotDotTest {
+    // Zip file to be created
+    private static final Path ZIPFILE = Path.of("zipfsDotDotTest.zip");
+    // Data for Zip entries
+    private static final byte[] ENTRY_DATA =
+            "Tennis Anyone".getBytes(StandardCharsets.UTF_8);
+    // Display output
+    private static final boolean DEBUG = false;
+
+    /**
+     * DataProvider containing Zip entry names which should result in an IOException
+     * @return Array of Zip entry names
+     */
+    @DataProvider
+    private Object[][] checkForDotOrDotDotPaths() {
+        return new Object[][]{
+                {"/./foo"},
+                {"/../foo"},
+                {"/../foo/.."},
+                {"/foo/.."},
+                {"/foo/."},
+                {"/.."},
+                {"/."},
+                {"/.foo/./"},
+                {"/.././"},
+        };
+    }
+
+    // Zip entry names to create a Zip file with for validating they are not
+    // interpreted as a "." or ".." entry
+    private final String[] VALID_PATHS =
+            {"/foo.txt", "/..foo.txt", "/.foo.txt", "/.foo/bar.txt", "/foo/bar.txt"};
+    // Paths to be returned from Files::walk via Zip FS
+    private final String[] EXPECTED_PATHS =
+            {"/", "/..foo.txt", "/foo.txt", "/.foo.txt", "/.foo",
+                    "/.foo/bar.txt", "/foo/bar.txt", "/foo"};
+
+    /**
+     * Creates a Zip file
+     * @param zip path for Zip to be created
+     * @param entries  the entries to add to the Zip file
+     * @throws IOException  if an error occurs
+     */
+    private static void createZip(Path zip, String... entries) throws IOException {
+        try (var os = Files.newOutputStream(zip);
+             ZipOutputStream zos = new ZipOutputStream(os)) {
+            for (var e : entries) {
+                var ze = new ZipEntry(e);
+                var crc = new CRC32();
+                ze.setMethod(ZipEntry.STORED);
+                crc.update(ENTRY_DATA);
+                ze.setCrc(crc.getValue());
+                ze.setSize(ENTRY_DATA.length);
+                zos.putNextEntry(ze);
+                zos.write(ENTRY_DATA);
+            }
+        }
+    }
+
+    /**
+     * Test to validate an IOException is thrown when opening a Zip file using
+     * Zip FS and the path contains a "." or ".."
+     * @param path
+     * @throws IOException
+     */
+    @Test(dataProvider = "checkForDotOrDotDotPaths")
+    public void hasDotOrDotDotTest(String path) throws IOException {
+        if (DEBUG) {
+            System.out.printf("Validating entry: %s%n", path);
+        }
+        Files.deleteIfExists(ZIPFILE);
+        createZip(ZIPFILE, path);
+        assertThrows(IOException.class, () ->
+                FileSystems.newFileSystem(ZIPFILE, Map.of()));
+        Files.deleteIfExists(ZIPFILE);
+    }
+
+    /**
+     * Validate that an entry with a name containing a "." or ".." can be
+     * accessed via Files::walk
+     * @throws IOException if an error occurs
+     */
+    @Test
+    public void validPaths() throws IOException {
+        Files.deleteIfExists(ZIPFILE);
+        createZip(ZIPFILE, VALID_PATHS);
+        /*
+          Walk through the Zip file and collect the Zip FS entries
+         */
+        try (FileSystem zipfs = FileSystems.newFileSystem(ZIPFILE)) {
+            Path zipRoot = zipfs.getPath("/");
+            try (Stream<Path> files = Files.walk(zipRoot, Integer.MAX_VALUE)) {
+                var entries = files.map(Path::toString)
+                        .sorted()
+                        .toArray(String[]::new);
+                if (DEBUG) {
+                    for (String zipEntry : entries) {
+                        System.out.println(zipEntry);
+                    }
+                }
+                Arrays.sort(EXPECTED_PATHS);
+                assertTrue(Arrays.equals(entries, EXPECTED_PATHS));
+            }
+        }
+        Files.deleteIfExists(ZIPFILE);
+    }
+}

--- a/test/jdk/jdk/nio/zipfs/HasDotDotTest.java
+++ b/test/jdk/jdk/nio/zipfs/HasDotDotTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -49,6 +50,7 @@ import static org.testng.Assert.assertTrue;
 public class HasDotDotTest {
     // Zip file to be created
     private static final Path ZIPFILE = Path.of("zipfsDotDotTest.zip");
+    private static final URI zipURI = URI.create("jar:" + ZIPFILE.toUri());
     // Data for Zip entries
     private static final byte[] ENTRY_DATA =
             "Tennis Anyone".getBytes(StandardCharsets.UTF_8);
@@ -119,7 +121,7 @@ public class HasDotDotTest {
         Files.deleteIfExists(ZIPFILE);
         createZip(ZIPFILE, path);
         assertThrows(IOException.class, () ->
-                FileSystems.newFileSystem(ZIPFILE, Map.of()));
+                FileSystems.newFileSystem(zipURI, Map.of()));
         Files.deleteIfExists(ZIPFILE);
     }
 
@@ -135,7 +137,7 @@ public class HasDotDotTest {
         /*
           Walk through the Zip file and collect the Zip FS entries
          */
-        try (FileSystem zipfs = FileSystems.newFileSystem(ZIPFILE)) {
+        try (FileSystem zipfs = FileSystems.newFileSystem(zipURI, Map.of())) {
             Path zipRoot = zipfs.getPath("/");
             try (Stream<Path> files = Files.walk(zipRoot, Integer.MAX_VALUE)) {
                 var entries = files.map(Path::toString)


### PR DESCRIPTION
Backport of 8251329: (zipfs) Files.walkFileTree walks infinitely if zip has dir named "." inside
The actual fix applies cleanly, but the comment changes in module-info.java need manual integration.
The new test requires adaption for 11u (see 2nd commit).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8251329](https://bugs.openjdk.java.net/browse/JDK-8251329): (zipfs) Files.walkFileTree walks infinitely if zip has dir named "." inside
 * [JDK-8271294](https://bugs.openjdk.java.net/browse/JDK-8271294): (zipfs) Files.walkFileTree walks infinitely if zip has dir named "." inside (**CSR**)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.java.net/jdk11u pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u/pull/19.diff">https://git.openjdk.java.net/jdk11u/pull/19.diff</a>

</details>
