### PR TITLE
8229258: Backport patch from JDK 14 to allow building with Clang 13

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3402,11 +3402,11 @@ encode %{
 
     // Check for existing monitor
     if ((EmitSync & 0x02) == 0) {
-      __ tbnz(disp_hdr, exact_log2(markOopDesc::monitor_value), object_has_monitor);
+      __ tbnz(disp_hdr, exact_log2(markOop::monitor_value), object_has_monitor);
     }
 
     // Set tmp to be (markOop of object | UNLOCK_VALUE).
-    __ orr(tmp, disp_hdr, markOopDesc::unlocked_value);
+    __ orr(tmp, disp_hdr, markOop::unlocked_value);
 
     // Initialize the box. (Must happen before we update the object mark!)
     __ str(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
@@ -3430,7 +3430,7 @@ encode %{
     // markOop of object (disp_hdr) with the stack pointer.
     __ mov(rscratch1, sp);
     __ sub(disp_hdr, disp_hdr, rscratch1);
-    __ mov(tmp, (address) (~(os::vm_page_size()-1) | (uintptr_t)markOopDesc::lock_mask_in_place));
+    __ mov(tmp, (address) (~(os::vm_page_size()-1) | (uintptr_t)markOop::lock_mask_in_place));
     // If condition is true we are cont and hence we can store 0 as the
     // displaced header in the box, which indicates that it is a recursive lock.
     __ ands(tmp/*==0?*/, disp_hdr, tmp);   // Sets flags for result
@@ -3445,15 +3445,15 @@ encode %{
       // otherwise m->owner may contain a thread or a stack address.
       //
       // Try to CAS m->owner from NULL to current thread.
-      __ add(tmp, disp_hdr, (ObjectMonitor::owner_offset_in_bytes()-markOopDesc::monitor_value));
+      __ add(tmp, disp_hdr, (ObjectMonitor::owner_offset_in_bytes()-markOop::monitor_value));
     __ cmpxchg(tmp, zr, rthread, Assembler::xword, /*acquire*/ true,
                /*release*/ true, /*weak*/ false, noreg); // Sets flags for result
 
       // Store a non-null value into the box to avoid looking like a re-entrant
       // lock. The fast-path monitor unlock code checks for
-      // markOopDesc::monitor_value so use markOopDesc::unused_mark which has the
+      // markOop::monitor_value so use markOop::unused_mark which has the
       // relevant bit set, and also matches ObjectSynchronizer::slow_enter.
-      __ mov(tmp, (address)markOopDesc::unused_mark());
+      __ mov(tmp, (address)markOop::unused_mark());
       __ str(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
     }
 
@@ -3493,7 +3493,7 @@ encode %{
     // Handle existing monitor.
     if ((EmitSync & 0x02) == 0) {
       __ ldr(tmp, Address(oop, oopDesc::mark_offset_in_bytes()));
-      __ tbnz(disp_hdr, exact_log2(markOopDesc::monitor_value), object_has_monitor);
+      __ tbnz(disp_hdr, exact_log2(markOop::monitor_value), object_has_monitor);
     }
 
     // Check if it is still a light weight lock, this is is true if we
@@ -3509,7 +3509,7 @@ encode %{
     // Handle existing monitor.
     if ((EmitSync & 0x02) == 0) {
       __ bind(object_has_monitor);
-      __ add(tmp, tmp, -markOopDesc::monitor_value); // monitor
+      __ add(tmp, tmp, -markOop::monitor_value); // monitor
       __ ldr(rscratch1, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
       __ ldr(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
       __ eor(rscratch1, rscratch1, rthread); // Will be 0 if we are the owner.

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -82,7 +82,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
   // Load object header
   ldr(hdr, Address(obj, hdr_offset));
   // and mark it as unlocked
-  orr(hdr, hdr, markOopDesc::unlocked_value);
+  orr(hdr, hdr, markOop::unlocked_value);
   // save unlocked object header into the displaced header location on the stack
   str(hdr, Address(disp_hdr, 0));
   // test if object header is still the same (i.e. unlocked), and if so, store the
@@ -176,7 +176,7 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
     ldr(t1, Address(klass, Klass::prototype_header_offset()));
   } else {
     // This assumes that all prototype bits fit in an int32_t
-    mov(t1, (int32_t)(intptr_t)markOopDesc::prototype());
+    mov(t1, (int32_t)(intptr_t)markOop::prototype());
   }
   str(t1, Address(obj, oopDesc::mark_offset_in_bytes()));
 

--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -215,9 +215,9 @@ void ShenandoahBarrierSetAssembler::resolve_forward_pointer_not_null(MacroAssemb
   Label done;
   __ ldr(tmp, Address(dst, oopDesc::mark_offset_in_bytes()));
   __ eon(tmp, tmp, zr);
-  __ ands(zr, tmp, markOopDesc::lock_mask_in_place);
+  __ ands(zr, tmp, markOop::lock_mask_in_place);
   __ br(Assembler::NE, done);
-  __ orr(tmp, tmp, markOopDesc::marked_value);
+  __ orr(tmp, tmp, markOop::marked_value);
   __ eon(dst, tmp, zr);
   __ bind(done);
 
@@ -616,11 +616,11 @@ void ShenandoahBarrierSetAssembler::gen_load_reference_barrier_stub(LIR_Assemble
   Label slow_path;
   __ ldr(tmp1, Address(res, oopDesc::mark_offset_in_bytes()));
   __ eon(tmp1, tmp1, zr);
-  __ ands(zr, tmp1, markOopDesc::lock_mask_in_place);
+  __ ands(zr, tmp1, markOop::lock_mask_in_place);
   __ br(Assembler::NE, slow_path);
 
   // Decode forwarded object.
-  __ orr(tmp1, tmp1, markOopDesc::marked_value);
+  __ orr(tmp1, tmp1, markOop::marked_value);
   __ eon(res, tmp1, zr);
   __ b(*stub->continuation());
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -475,7 +475,7 @@ int MacroAssembler::biased_locking_enter(Register lock_reg,
     counters = BiasedLocking::counters();
 
   assert_different_registers(lock_reg, obj_reg, swap_reg, tmp_reg, rscratch1, rscratch2, noreg);
-  assert(markOopDesc::age_shift == markOopDesc::lock_bits + markOopDesc::biased_lock_bits, "biased locking makes assumptions about bit layout");
+  assert(markOop::age_shift == markOop::lock_bits + markOop::biased_lock_bits, "biased locking makes assumptions about bit layout");
   Address mark_addr      (obj_reg, oopDesc::mark_offset_in_bytes());
   Address klass_addr     (obj_reg, oopDesc::klass_offset_in_bytes());
   Address saved_mark_addr(lock_reg, 0);
@@ -492,15 +492,15 @@ int MacroAssembler::biased_locking_enter(Register lock_reg,
     null_check_offset = offset();
     ldr(swap_reg, mark_addr);
   }
-  andr(tmp_reg, swap_reg, markOopDesc::biased_lock_mask_in_place);
-  cmp(tmp_reg, markOopDesc::biased_lock_pattern);
+  andr(tmp_reg, swap_reg, markOop::biased_lock_mask_in_place);
+  cmp(tmp_reg, markOop::biased_lock_pattern);
   br(Assembler::NE, cas_label);
   // The bias pattern is present in the object's header. Need to check
   // whether the bias owner and the epoch are both still current.
   load_prototype_header(tmp_reg, obj_reg);
   orr(tmp_reg, tmp_reg, rthread);
   eor(tmp_reg, swap_reg, tmp_reg);
-  andr(tmp_reg, tmp_reg, ~((int) markOopDesc::age_mask_in_place));
+  andr(tmp_reg, tmp_reg, ~((int) markOop::age_mask_in_place));
   if (counters != NULL) {
     Label around;
     cbnz(tmp_reg, around);
@@ -523,7 +523,7 @@ int MacroAssembler::biased_locking_enter(Register lock_reg,
   // If the low three bits in the xor result aren't clear, that means
   // the prototype header is no longer biased and we have to revoke
   // the bias on this object.
-  andr(rscratch1, tmp_reg, markOopDesc::biased_lock_mask_in_place);
+  andr(rscratch1, tmp_reg, markOop::biased_lock_mask_in_place);
   cbnz(rscratch1, try_revoke_bias);
 
   // Biasing is still enabled for this data type. See whether the
@@ -535,7 +535,7 @@ int MacroAssembler::biased_locking_enter(Register lock_reg,
   // that the current epoch is invalid in order to do this because
   // otherwise the manipulations it performs on the mark word are
   // illegal.
-  andr(rscratch1, tmp_reg, markOopDesc::epoch_mask_in_place);
+  andr(rscratch1, tmp_reg, markOop::epoch_mask_in_place);
   cbnz(rscratch1, try_rebias);
 
   // The epoch of the current bias is still valid but we know nothing
@@ -546,7 +546,7 @@ int MacroAssembler::biased_locking_enter(Register lock_reg,
   // don't accidentally blow away another thread's valid bias.
   {
     Label here;
-    mov(rscratch1, markOopDesc::biased_lock_mask_in_place | markOopDesc::age_mask_in_place | markOopDesc::epoch_mask_in_place);
+    mov(rscratch1, markOop::biased_lock_mask_in_place | markOop::age_mask_in_place | markOop::epoch_mask_in_place);
     andr(swap_reg, swap_reg, rscratch1);
     orr(tmp_reg, swap_reg, rthread);
     cmpxchg_obj_header(swap_reg, tmp_reg, obj_reg, rscratch1, here, slow_case);
@@ -631,8 +631,8 @@ void MacroAssembler::biased_locking_exit(Register obj_reg, Register temp_reg, La
   // lock, the object could not be rebiased toward another thread, so
   // the bias bit would be clear.
   ldr(temp_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-  andr(temp_reg, temp_reg, markOopDesc::biased_lock_mask_in_place);
-  cmp(temp_reg, markOopDesc::biased_lock_pattern);
+  andr(temp_reg, temp_reg, markOop::biased_lock_mask_in_place);
+  cmp(temp_reg, markOop::biased_lock_pattern);
   br(Assembler::EQ, done);
 }
 

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3613,7 +3613,7 @@ void TemplateTable::_new() {
     if (UseBiasedLocking) {
       __ ldr(rscratch1, Address(r4, Klass::prototype_header_offset()));
     } else {
-      __ mov(rscratch1, (intptr_t)markOopDesc::prototype());
+      __ mov(rscratch1, (intptr_t)markOop::prototype());
     }
     __ str(rscratch1, Address(r0, oopDesc::mark_offset_in_bytes()));
     __ store_klass_gap(r0, zr);  // zero klass gap for compressed oops

--- a/src/hotspot/cpu/arm/c1_MacroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_MacroAssembler_arm.cpp
@@ -101,7 +101,7 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
   if(UseBiasedLocking && !len->is_valid()) {
     ldr(tmp, Address(klass, Klass::prototype_header_offset()));
   } else {
-    mov(tmp, (intptr_t)markOopDesc::prototype());
+    mov(tmp, (intptr_t)markOop::prototype());
   }
 
 #ifdef AARCH64
@@ -282,8 +282,8 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj,
   ldr(hdr, obj);
 
   // Test if object is already locked
-  assert(markOopDesc::unlocked_value == 1, "adjust this code");
-  tbnz(hdr, exact_log2(markOopDesc::unlocked_value), fast_lock);
+  assert(markOop::unlocked_value == 1, "adjust this code");
+  tbnz(hdr, exact_log2(markOop::unlocked_value), fast_lock);
 
   // Check for recursive locking
   // See comments in InterpreterMacroAssembler::lock_object for
@@ -312,7 +312,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj,
   ldr(hdr, Address(obj, oopDesc::mark_offset_in_bytes()));
 
   str(obj, Address(disp_hdr, obj_offset));
-  tst(hdr, markOopDesc::unlocked_value);
+  tst(hdr, markOop::unlocked_value);
   b(fast_lock, ne);
 
   // Check for recursive locking

--- a/src/hotspot/cpu/arm/interp_masm_arm.cpp
+++ b/src/hotspot/cpu/arm/interp_masm_arm.cpp
@@ -995,8 +995,8 @@ void InterpreterMacroAssembler::lock_object(Register Rlock) {
     ldr(Rmark, Robj);
 
     // Test if object is already locked
-    assert(markOopDesc::unlocked_value == 1, "adjust this code");
-    tbz(Rmark, exact_log2(markOopDesc::unlocked_value), already_locked);
+    assert(markOop::unlocked_value == 1, "adjust this code");
+    tbz(Rmark, exact_log2(markOop::unlocked_value), already_locked);
 
 #else // AARCH64
 
@@ -1009,7 +1009,7 @@ void InterpreterMacroAssembler::lock_object(Register Rlock) {
     ldr(Rmark, Address(Robj, oopDesc::mark_offset_in_bytes()));
 
     // Test if object is already locked
-    tst(Rmark, markOopDesc::unlocked_value);
+    tst(Rmark, markOop::unlocked_value);
     b(already_locked, eq);
 
 #endif // !AARCH64

--- a/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
+++ b/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
@@ -1228,22 +1228,22 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
     __ ldr(Rtemp, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
 
-    assert(markOopDesc::unlocked_value == 1, "adjust this code");
-    __ tbz(Rtemp, exact_log2(markOopDesc::unlocked_value), slow_case);
+    assert(markOop::unlocked_value == 1, "adjust this code");
+    __ tbz(Rtemp, exact_log2(markOop::unlocked_value), slow_case);
 
     if (UseBiasedLocking) {
-      assert(is_power_of_2(markOopDesc::biased_lock_bit_in_place), "adjust this code");
-      __ tbnz(Rtemp, exact_log2(markOopDesc::biased_lock_bit_in_place), slow_case);
+      assert(is_power_of_2(markOop::biased_lock_bit_in_place), "adjust this code");
+      __ tbnz(Rtemp, exact_log2(markOop::biased_lock_bit_in_place), slow_case);
     }
 
 #ifdef AARCH64
-    __ ands(Rtemp, Rtemp, (uintx)markOopDesc::hash_mask_in_place);
+    __ ands(Rtemp, Rtemp, (uintx)markOop::hash_mask_in_place);
     __ b(slow_case, eq);
-    __ logical_shift_right(R0, Rtemp, markOopDesc::hash_shift);
+    __ logical_shift_right(R0, Rtemp, markOop::hash_shift);
     __ ret();
 #else
-    __ bics(Rtemp, Rtemp, ~markOopDesc::hash_mask_in_place);
-    __ mov(R0, AsmOperand(Rtemp, lsr, markOopDesc::hash_shift), ne);
+    __ bics(Rtemp, Rtemp, ~markOop::hash_mask_in_place);
+    __ mov(R0, AsmOperand(Rtemp, lsr, markOop::hash_shift), ne);
     __ bx(LR, ne);
 #endif // AARCH64
 
@@ -1583,8 +1583,8 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ ldr(mark, sync_obj);
 
     // Test if object is already locked
-    assert(markOopDesc::unlocked_value == 1, "adjust this code");
-    __ tbnz(mark, exact_log2(markOopDesc::unlocked_value), fast_lock);
+    assert(markOop::unlocked_value == 1, "adjust this code");
+    __ tbnz(mark, exact_log2(markOop::unlocked_value), fast_lock);
 
     // Check for recursive lock
     // See comments in InterpreterMacroAssembler::lock_object for
@@ -1610,7 +1610,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
     __ ldr(mark, Address(sync_obj, oopDesc::mark_offset_in_bytes()));
     __ sub(disp_hdr, FP, lock_slot_fp_offset);
-    __ tst(mark, markOopDesc::unlocked_value);
+    __ tst(mark, markOop::unlocked_value);
     __ b(fast_lock, ne);
 
     // Check for recursive lock

--- a/src/hotspot/cpu/arm/templateTable_arm.cpp
+++ b/src/hotspot/cpu/arm/templateTable_arm.cpp
@@ -4607,7 +4607,7 @@ void TemplateTable::_new() {
     if (UseBiasedLocking) {
       __ ldr(Rtemp, Address(Rklass, Klass::prototype_header_offset()));
     } else {
-      __ mov_slow(Rtemp, (intptr_t)markOopDesc::prototype());
+      __ mov_slow(Rtemp, (intptr_t)markOop::prototype());
     }
     // mark
     __ str(Rtemp, Address(Robj, oopDesc::mark_offset_in_bytes()));

--- a/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
@@ -110,7 +110,7 @@ void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox
   }
 
   // ... and mark it unlocked.
-  ori(Rmark, Rmark, markOopDesc::unlocked_value);
+  ori(Rmark, Rmark, markOop::unlocked_value);
 
   // Save unlocked object header into the displaced header location on the stack.
   std(Rmark, BasicLock::displaced_header_offset_in_bytes(), Rbox);
@@ -137,7 +137,7 @@ void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox
   bind(cas_failed);
   // We did not find an unlocked object so see if this is a recursive case.
   sub(Rscratch, Rscratch, R1_SP);
-  load_const_optimized(R0, (~(os::vm_page_size()-1) | markOopDesc::lock_mask_in_place));
+  load_const_optimized(R0, (~(os::vm_page_size()-1) | markOop::lock_mask_in_place));
   and_(R0/*==0?*/, Rscratch, R0);
   std(R0/*==0, perhaps*/, BasicLock::displaced_header_offset_in_bytes(), Rbox);
   bne(CCR0, slow_int);
@@ -215,7 +215,7 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
   if (UseBiasedLocking && !len->is_valid()) {
     ld(t1, in_bytes(Klass::prototype_header_offset()), klass);
   } else {
-    load_const_optimized(t1, (intx)markOopDesc::prototype());
+    load_const_optimized(t1, (intx)markOop::prototype());
   }
   std(t1, oopDesc::mark_offset_in_bytes(), obj);
   store_klass(obj, klass);

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -901,7 +901,7 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
     }
 
     // Set displaced_header to be (markOop of object | UNLOCK_VALUE).
-    ori(displaced_header, displaced_header, markOopDesc::unlocked_value);
+    ori(displaced_header, displaced_header, markOop::unlocked_value);
 
     // monitor->lock()->set_displaced_header(displaced_header);
 
@@ -942,7 +942,7 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
     sub(current_header, current_header, R1_SP);
 
     assert(os::vm_page_size() > 0xfff, "page size too small - change the constant");
-    load_const_optimized(tmp, ~(os::vm_page_size()-1) | markOopDesc::lock_mask_in_place);
+    load_const_optimized(tmp, ~(os::vm_page_size()-1) | markOop::lock_mask_in_place);
 
     and_(R0/*==0?*/, current_header, tmp);
     // If condition is true we are done and hence we can store 0 in the displaced

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -2089,7 +2089,7 @@ void MacroAssembler::biased_locking_enter(ConditionRegister cr_reg, Register obj
   // whether the epoch is still valid
   // Note that the runtime guarantees sufficient alignment of JavaThread
   // pointers to allow age to be placed into low bits
-  assert(markOopDesc::age_shift == markOopDesc::lock_bits + markOopDesc::biased_lock_bits,
+  assert(markOop::age_shift == markOop::lock_bits + markOop::biased_lock_bits,
          "biased locking makes assumptions about bit layout");
 
   if (PrintBiasedLockingStatistics) {
@@ -2099,13 +2099,13 @@ void MacroAssembler::biased_locking_enter(ConditionRegister cr_reg, Register obj
     stwx(temp_reg, temp2_reg);
   }
 
-  andi(temp_reg, mark_reg, markOopDesc::biased_lock_mask_in_place);
-  cmpwi(cr_reg, temp_reg, markOopDesc::biased_lock_pattern);
+  andi(temp_reg, mark_reg, markOop::biased_lock_mask_in_place);
+  cmpwi(cr_reg, temp_reg, markOop::biased_lock_pattern);
   bne(cr_reg, cas_label);
 
   load_klass(temp_reg, obj_reg);
 
-  load_const_optimized(temp2_reg, ~((int) markOopDesc::age_mask_in_place));
+  load_const_optimized(temp2_reg, ~((int) markOop::age_mask_in_place));
   ld(temp_reg, in_bytes(Klass::prototype_header_offset()), temp_reg);
   orr(temp_reg, R16_thread, temp_reg);
   xorr(temp_reg, mark_reg, temp_reg);
@@ -2136,7 +2136,7 @@ void MacroAssembler::biased_locking_enter(ConditionRegister cr_reg, Register obj
   // If the low three bits in the xor result aren't clear, that means
   // the prototype header is no longer biased and we have to revoke
   // the bias on this object.
-  andi(temp2_reg, temp_reg, markOopDesc::biased_lock_mask_in_place);
+  andi(temp2_reg, temp_reg, markOop::biased_lock_mask_in_place);
   cmpwi(cr_reg, temp2_reg, 0);
   bne(cr_reg, try_revoke_bias);
 
@@ -2150,10 +2150,10 @@ void MacroAssembler::biased_locking_enter(ConditionRegister cr_reg, Register obj
   // otherwise the manipulations it performs on the mark word are
   // illegal.
 
-  int shift_amount = 64 - markOopDesc::epoch_shift;
+  int shift_amount = 64 - markOop::epoch_shift;
   // rotate epoch bits to right (little) end and set other bits to 0
   // [ big part | epoch | little part ] -> [ 0..0 | epoch ]
-  rldicl_(temp2_reg, temp_reg, shift_amount, 64 - markOopDesc::epoch_bits);
+  rldicl_(temp2_reg, temp_reg, shift_amount, 64 - markOop::epoch_bits);
   // branch if epoch bits are != 0, i.e. they differ, because the epoch has been incremented
   bne(CCR0, try_rebias);
 
@@ -2163,9 +2163,9 @@ void MacroAssembler::biased_locking_enter(ConditionRegister cr_reg, Register obj
   // fails we will go in to the runtime to revoke the object's bias.
   // Note that we first construct the presumed unbiased header so we
   // don't accidentally blow away another thread's valid bias.
-  andi(mark_reg, mark_reg, (markOopDesc::biased_lock_mask_in_place |
-                                markOopDesc::age_mask_in_place |
-                                markOopDesc::epoch_mask_in_place));
+  andi(mark_reg, mark_reg, (markOop::biased_lock_mask_in_place |
+                                markOop::age_mask_in_place |
+                                markOop::epoch_mask_in_place));
   orr(temp_reg, R16_thread, mark_reg);
 
   assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
@@ -2198,7 +2198,7 @@ void MacroAssembler::biased_locking_enter(ConditionRegister cr_reg, Register obj
   // bias in the current epoch. In other words, we allow transfer of
   // the bias from one thread to another directly in this situation.
   load_klass(temp_reg, obj_reg);
-  andi(temp2_reg, mark_reg, markOopDesc::age_mask_in_place);
+  andi(temp2_reg, mark_reg, markOop::age_mask_in_place);
   orr(temp2_reg, R16_thread, temp2_reg);
   ld(temp_reg, in_bytes(Klass::prototype_header_offset()), temp_reg);
   orr(temp_reg, temp2_reg, temp_reg);
@@ -2235,7 +2235,7 @@ void MacroAssembler::biased_locking_enter(ConditionRegister cr_reg, Register obj
   // normal locking code.
   load_klass(temp_reg, obj_reg);
   ld(temp_reg, in_bytes(Klass::prototype_header_offset()), temp_reg);
-  andi(temp2_reg, mark_reg, markOopDesc::age_mask_in_place);
+  andi(temp2_reg, mark_reg, markOop::age_mask_in_place);
   orr(temp_reg, temp_reg, temp2_reg);
 
   assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
@@ -2275,9 +2275,9 @@ void MacroAssembler::biased_locking_exit (ConditionRegister cr_reg, Register mar
   // the bias bit would be clear.
 
   ld(temp_reg, 0, mark_addr);
-  andi(temp_reg, temp_reg, markOopDesc::biased_lock_mask_in_place);
+  andi(temp_reg, temp_reg, markOop::biased_lock_mask_in_place);
 
-  cmpwi(cr_reg, temp_reg, markOopDesc::biased_lock_pattern);
+  cmpwi(cr_reg, temp_reg, markOop::biased_lock_pattern);
   beq(cr_reg, done);
 }
 
@@ -2698,7 +2698,7 @@ void MacroAssembler::rtm_stack_locking(ConditionRegister flag,
     load_const_optimized(retry_on_abort_count_Reg, RTMRetryCount); // Retry on abort
     bind(L_rtm_retry);
   }
-  andi_(R0, mark_word, markOopDesc::monitor_value);  // inflated vs stack-locked|neutral|biased
+  andi_(R0, mark_word, markOop::monitor_value);  // inflated vs stack-locked|neutral|biased
   bne(CCR0, IsInflated);
 
   if (PrintPreciseRTMLockingStatistics || profile_rtm) {
@@ -2717,8 +2717,8 @@ void MacroAssembler::rtm_stack_locking(ConditionRegister flag,
   tbegin_();
   beq(CCR0, L_on_abort);
   ld(mark_word, oopDesc::mark_offset_in_bytes(), obj);         // Reload in transaction, conflicts need to be tracked.
-  andi(R0, mark_word, markOopDesc::biased_lock_mask_in_place); // look at 3 lock bits
-  cmpwi(flag, R0, markOopDesc::unlocked_value);                // bits = 001 unlocked
+  andi(R0, mark_word, markOop::biased_lock_mask_in_place); // look at 3 lock bits
+  cmpwi(flag, R0, markOop::unlocked_value);                // bits = 001 unlocked
   beq(flag, DONE_LABEL);                                       // all done if unlocked
 
   if (UseRTMXendForLockBusy) {
@@ -2755,9 +2755,9 @@ void MacroAssembler::rtm_inflated_locking(ConditionRegister flag,
   assert(UseRTMLocking, "why call this otherwise?");
   Label L_rtm_retry, L_decrement_retry, L_on_abort;
   // Clean monitor_value bit to get valid pointer.
-  int owner_offset = ObjectMonitor::owner_offset_in_bytes() - markOopDesc::monitor_value;
+  int owner_offset = ObjectMonitor::owner_offset_in_bytes() - markOop::monitor_value;
 
-  // Store non-null, using boxReg instead of (intptr_t)markOopDesc::unused_mark().
+  // Store non-null, using boxReg instead of (intptr_t)markOop::unused_mark().
   std(boxReg, BasicLock::displaced_header_offset_in_bytes(), boxReg);
   const Register tmpReg = boxReg;
   const Register owner_addr_Reg = mark_word;
@@ -2802,7 +2802,7 @@ void MacroAssembler::rtm_inflated_locking(ConditionRegister flag,
     // Restore owner_addr_Reg
     ld(mark_word, oopDesc::mark_offset_in_bytes(), obj);
 #ifdef ASSERT
-    andi_(R0, mark_word, markOopDesc::monitor_value);
+    andi_(R0, mark_word, markOop::monitor_value);
     asm_assert_ne("must be inflated", 0xa754); // Deflating only allowed at safepoint.
 #endif
     addi(owner_addr_Reg, mark_word, owner_offset);
@@ -2869,12 +2869,12 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
   // Handle existing monitor.
   if ((EmitSync & 0x02) == 0) {
     // The object has an existing monitor iff (mark & monitor_value) != 0.
-    andi_(temp, displaced_header, markOopDesc::monitor_value);
+    andi_(temp, displaced_header, markOop::monitor_value);
     bne(CCR0, object_has_monitor);
   }
 
   // Set displaced_header to be (markOop of object | UNLOCK_VALUE).
-  ori(displaced_header, displaced_header, markOopDesc::unlocked_value);
+  ori(displaced_header, displaced_header, markOop::unlocked_value);
 
   // Load Compare Value application register.
 
@@ -2905,7 +2905,7 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
   // Check if the owner is self by comparing the value in the markOop of object
   // (current_header) with the stack pointer.
   sub(current_header, current_header, R1_SP);
-  load_const_optimized(temp, ~(os::vm_page_size()-1) | markOopDesc::lock_mask_in_place);
+  load_const_optimized(temp, ~(os::vm_page_size()-1) | markOop::lock_mask_in_place);
 
   and_(R0/*==0?*/, current_header, temp);
   // If condition is true we are cont and hence we can store 0 as the
@@ -2930,7 +2930,7 @@ void MacroAssembler::compiler_fast_lock_object(ConditionRegister flag, Register 
 #endif // INCLUDE_RTM_OPT
 
     // Try to CAS m->owner from NULL to current thread.
-    addi(temp, displaced_header, ObjectMonitor::owner_offset_in_bytes()-markOopDesc::monitor_value);
+    addi(temp, displaced_header, ObjectMonitor::owner_offset_in_bytes()-markOop::monitor_value);
     cmpxchgd(/*flag=*/flag,
              /*current_value=*/current_header,
              /*compare_value=*/(intptr_t)0,
@@ -2985,8 +2985,8 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
     assert(!UseBiasedLocking, "Biased locking is not supported with RTM locking");
     Label L_regular_unlock;
     ld(current_header, oopDesc::mark_offset_in_bytes(), oop);         // fetch markword
-    andi(R0, current_header, markOopDesc::biased_lock_mask_in_place); // look at 3 lock bits
-    cmpwi(flag, R0, markOopDesc::unlocked_value);                     // bits = 001 unlocked
+    andi(R0, current_header, markOop::biased_lock_mask_in_place); // look at 3 lock bits
+    cmpwi(flag, R0, markOop::unlocked_value);                     // bits = 001 unlocked
     bne(flag, L_regular_unlock);                                      // else RegularLock
     tend_();                                                          // otherwise end...
     b(cont);                                                          // ... and we're done
@@ -3006,7 +3006,7 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
     // The object has an existing monitor iff (mark & monitor_value) != 0.
     RTM_OPT_ONLY( if (!(UseRTMForStackLocks && use_rtm)) ) // skip load if already done
     ld(current_header, oopDesc::mark_offset_in_bytes(), oop);
-    andi_(R0, current_header, markOopDesc::monitor_value);
+    andi_(R0, current_header, markOop::monitor_value);
     bne(CCR0, object_has_monitor);
   }
 
@@ -3030,7 +3030,7 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
     b(cont);
 
     bind(object_has_monitor);
-    addi(current_header, current_header, -markOopDesc::monitor_value); // monitor
+    addi(current_header, current_header, -markOop::monitor_value); // monitor
     ld(temp,             ObjectMonitor::owner_offset_in_bytes(), current_header);
 
     // It's inflated.

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -3806,7 +3806,7 @@ void TemplateTable::_new() {
     if (UseBiasedLocking) {
       __ ld(Rscratch, in_bytes(Klass::prototype_header_offset()), RinstanceKlass);
     } else {
-      __ load_const_optimized(Rscratch, markOopDesc::prototype(), R0);
+      __ load_const_optimized(Rscratch, markOop::prototype(), R0);
     }
     __ std(Rscratch, oopDesc::mark_offset_in_bytes(), RallocatedObject);
 

--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -96,7 +96,7 @@ void C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hd
   }
 
   // and mark it as unlocked.
-  z_oill(hdr, markOopDesc::unlocked_value);
+  z_oill(hdr, markOop::unlocked_value);
   // Save unlocked object header into the displaced header location on the stack.
   z_stg(hdr, Address(disp_hdr, (intptr_t)0));
   // Test if object header is still the same (i.e. unlocked), and if so, store the
@@ -115,19 +115,19 @@ void C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hd
   // If the object header was not the same, it is now in the hdr register.
   // => Test if it is a stack pointer into the same stack (recursive locking), i.e.:
   //
-  // 1) (hdr & markOopDesc::lock_mask_in_place) == 0
+  // 1) (hdr & markOop::lock_mask_in_place) == 0
   // 2) rsp <= hdr
   // 3) hdr <= rsp + page_size
   //
   // These 3 tests can be done by evaluating the following expression:
   //
-  // (hdr - Z_SP) & (~(page_size-1) | markOopDesc::lock_mask_in_place)
+  // (hdr - Z_SP) & (~(page_size-1) | markOop::lock_mask_in_place)
   //
   // assuming both the stack pointer and page_size have their least
   // significant 2 bits cleared and page_size is a power of 2
   z_sgr(hdr, Z_SP);
 
-  load_const_optimized(Z_R0_scratch, (~(os::vm_page_size()-1) | markOopDesc::lock_mask_in_place));
+  load_const_optimized(Z_R0_scratch, (~(os::vm_page_size()-1) | markOop::lock_mask_in_place));
   z_ngr(hdr, Z_R0_scratch); // AND sets CC (result eq/ne 0).
   // For recursive locking, the result is zero. => Save it in the displaced header
   // location (NULL in the displaced hdr location indicates recursive locking).
@@ -192,7 +192,7 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
     z_lg(t1, Address(klass, Klass::prototype_header_offset()));
   } else {
     // This assumes that all prototype bits fit in an int32_t.
-    load_const_optimized(t1, (intx)markOopDesc::prototype());
+    load_const_optimized(t1, (intx)markOop::prototype());
   }
   z_stg(t1, Address(obj, oopDesc::mark_offset_in_bytes()));
 

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -989,7 +989,7 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
   }
 
   // Set displaced_header to be (markOop of object | UNLOCK_VALUE).
-  z_oill(displaced_header, markOopDesc::unlocked_value);
+  z_oill(displaced_header, markOop::unlocked_value);
 
   // monitor->lock()->set_displaced_header(displaced_header);
 
@@ -1021,7 +1021,7 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
 
   // The prior sequence "LGR, NGR, LTGR" can be done better
   // (Z_R1 is temp and not used after here).
-  load_const_optimized(Z_R0, (~(os::vm_page_size()-1) | markOopDesc::lock_mask_in_place));
+  load_const_optimized(Z_R0, (~(os::vm_page_size()-1) | markOop::lock_mask_in_place));
   z_ngr(Z_R0, current_header); // AND sets CC (result eq/ne 0)
 
   // If condition is true we are done and hence we can store 0 in the displaced

--- a/src/hotspot/cpu/s390/templateTable_s390.cpp
+++ b/src/hotspot/cpu/s390/templateTable_s390.cpp
@@ -3865,7 +3865,7 @@ void TemplateTable::_new() {
       __ z_stg(prototype, Address(RallocatedObject, oopDesc::mark_offset_in_bytes()));
     } else {
       __ store_const(Address(RallocatedObject, oopDesc::mark_offset_in_bytes()),
-                     (long)markOopDesc::prototype());
+                     (long)markOop::prototype());
     }
 
     __ store_klass_gap(Rzero, RallocatedObject);  // Zero klass gap for compressed oops.

--- a/src/hotspot/cpu/sparc/c1_MacroAssembler_sparc.cpp
+++ b/src/hotspot/cpu/sparc/c1_MacroAssembler_sparc.cpp
@@ -97,7 +97,7 @@ void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox
   mov(Rbox, Rscratch);
 
   // and mark it unlocked
-  or3(Rmark, markOopDesc::unlocked_value, Rmark);
+  or3(Rmark, markOop::unlocked_value, Rmark);
 
   // save unlocked object header into the displaced header location on the stack
   st_ptr(Rmark, Rbox, BasicLock::displaced_header_offset_in_bytes());
@@ -179,7 +179,7 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
   if (UseBiasedLocking && !len->is_valid()) {
     ld_ptr(klass, in_bytes(Klass::prototype_header_offset()), t1);
   } else {
-    set((intx)markOopDesc::prototype(), t1);
+    set((intx)markOop::prototype(), t1);
   }
   st_ptr(t1, obj, oopDesc::mark_offset_in_bytes());
   if (UseCompressedClassPointers) {

--- a/src/hotspot/cpu/sparc/interp_masm_sparc.cpp
+++ b/src/hotspot/cpu/sparc/interp_masm_sparc.cpp
@@ -1212,7 +1212,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg, Register Object) 
     // (cas clobbers the destination register)
     mov(lock_reg, temp_reg);
     // set mark reg to be (markOop of object | UNLOCK_VALUE)
-    or3(mark_reg, markOopDesc::unlocked_value, mark_reg);
+    or3(mark_reg, markOop::unlocked_value, mark_reg);
     // initialize the box  (Must happen before we update the object mark!)
     st_ptr(mark_reg, lock_addr, BasicLock::displaced_header_offset_in_bytes());
     // compare and exchange object_addr, markOop | 1, stack address of basicLock
@@ -1234,7 +1234,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg, Register Object) 
     // (a) %sp -vs- markword proximity check, and,
     // (b) verify mark word LSBs == 0 (Stack-locked).
     //
-    // FFFFF003/FFFFFFFFFFFF003 is (markOopDesc::lock_mask_in_place | -os::vm_page_size())
+    // FFFFF003/FFFFFFFFFFFF003 is (markOop::lock_mask_in_place | -os::vm_page_size())
     // Note that the page size used for %sp proximity testing is arbitrary and is
     // unrelated to the actual MMU page size.  We use a 'logical' page size of
     // 4096 bytes.   F..FFF003 is designed to fit conveniently in the SIMM13 immediate

--- a/src/hotspot/cpu/sparc/sharedRuntime_sparc.cpp
+++ b/src/hotspot/cpu/sparc/sharedRuntime_sparc.cpp
@@ -1835,19 +1835,19 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // hash_mask_in_place because it could be larger than 32 bits in a 64-bit
     // vm: see markOop.hpp.
     __ ld_ptr(obj_reg, oopDesc::mark_offset_in_bytes(), header);
-    __ sethi(markOopDesc::hash_mask, mask);
-    __ btst(markOopDesc::unlocked_value, header);
+    __ sethi(markOop::hash_mask, mask);
+    __ btst(markOop::unlocked_value, header);
     __ br(Assembler::zero, false, Assembler::pn, slowCase);
     if (UseBiasedLocking) {
       // Check if biased and fall through to runtime if so
       __ delayed()->nop();
-      __ btst(markOopDesc::biased_lock_bit_in_place, header);
+      __ btst(markOop::biased_lock_bit_in_place, header);
       __ br(Assembler::notZero, false, Assembler::pn, slowCase);
     }
-    __ delayed()->or3(mask, markOopDesc::hash_mask & 0x3ff, mask);
+    __ delayed()->or3(mask, markOop::hash_mask & 0x3ff, mask);
 
     // Check for a valid (non-zero) hash code and get its value.
-    __ srlx(header, markOopDesc::hash_shift, hash);
+    __ srlx(header, markOop::hash_shift, hash);
     __ andcc(hash, mask, hash);
     __ br(Assembler::equal, false, Assembler::pn, slowCase);
     __ delayed()->nop();

--- a/src/hotspot/cpu/sparc/templateTable_sparc.cpp
+++ b/src/hotspot/cpu/sparc/templateTable_sparc.cpp
@@ -3518,7 +3518,7 @@ void TemplateTable::_new() {
   if (UseBiasedLocking) {
     __ ld_ptr(RinstanceKlass, in_bytes(Klass::prototype_header_offset()), G4_scratch);
   } else {
-    __ set((intptr_t)markOopDesc::prototype(), G4_scratch);
+    __ set((intptr_t)markOop::prototype(), G4_scratch);
   }
   __ st_ptr(G4_scratch, RallocatedObject, oopDesc::mark_offset_in_bytes());       // mark
   __ store_klass_gap(G0, RallocatedObject);         // klass gap if compressed

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -59,7 +59,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
   // Load object header
   movptr(hdr, Address(obj, hdr_offset));
   // and mark it as unlocked
-  orptr(hdr, markOopDesc::unlocked_value);
+  orptr(hdr, markOop::unlocked_value);
   // save unlocked object header into the displaced header location on the stack
   movptr(Address(disp_hdr, 0), hdr);
   // test if object header is still the same (i.e. unlocked), and if so, store the
@@ -154,7 +154,7 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
     movptr(Address(obj, oopDesc::mark_offset_in_bytes()), t1);
   } else {
     // This assumes that all prototype bits fit in an int32_t
-    movptr(Address(obj, oopDesc::mark_offset_in_bytes ()), (int32_t)(intptr_t)markOopDesc::prototype());
+    movptr(Address(obj, oopDesc::mark_offset_in_bytes ()), (int32_t)(intptr_t)markOop::prototype().value());
   }
 #ifdef _LP64
   if (UseCompressedClassPointers) { // Take care not to kill klass

--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -653,7 +653,7 @@ void ShenandoahBarrierSetAssembler::cmpxchg_oop(MacroAssembler* masm,
 
   // Decode offending in-memory value.
   // Test if-forwarded
-  __ testb(Address(tmp2, oopDesc::mark_offset_in_bytes()), markOopDesc::marked_value);
+  __ testb(Address(tmp2, oopDesc::mark_offset_in_bytes()), markOop::marked_value);
   __ jcc(Assembler::noParity, L_failure);  // When odd number of bits, then not forwarded
   __ jcc(Assembler::zero, L_failure);      // When it is 00, then also not forwarded
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1118,7 +1118,7 @@ int MacroAssembler::biased_locking_enter(Register lock_reg,
   assert(swap_reg == rax, "swap_reg must be rax for cmpxchgq");
   assert(tmp_reg != noreg, "tmp_reg must be supplied");
   assert_different_registers(lock_reg, obj_reg, swap_reg, tmp_reg);
-  assert(markOopDesc::age_shift == markOopDesc::lock_bits + markOopDesc::biased_lock_bits, "biased locking makes assumptions about bit layout");
+  assert(markOop::age_shift == markOop::lock_bits + markOop::biased_lock_bits, "biased locking makes assumptions about bit layout");
   Address mark_addr      (obj_reg, oopDesc::mark_offset_in_bytes());
   NOT_LP64( Address saved_mark_addr(lock_reg, 0); )
 
@@ -1138,8 +1138,8 @@ int MacroAssembler::biased_locking_enter(Register lock_reg,
     movptr(swap_reg, mark_addr);
   }
   movptr(tmp_reg, swap_reg);
-  andptr(tmp_reg, markOopDesc::biased_lock_mask_in_place);
-  cmpptr(tmp_reg, markOopDesc::biased_lock_pattern);
+  andptr(tmp_reg, markOop::biased_lock_mask_in_place);
+  cmpptr(tmp_reg, markOop::biased_lock_pattern);
   jcc(Assembler::notEqual, cas_label);
   // The bias pattern is present in the object's header. Need to check
   // whether the bias owner and the epoch are both still current.
@@ -1165,7 +1165,7 @@ int MacroAssembler::biased_locking_enter(Register lock_reg,
   xorptr(swap_reg, tmp_reg);
   Register header_reg = swap_reg;
 #endif
-  andptr(header_reg, ~((int) markOopDesc::age_mask_in_place));
+  andptr(header_reg, ~((int) markOop::age_mask_in_place));
   if (counters != NULL) {
     cond_inc32(Assembler::zero,
                ExternalAddress((address) counters->biased_lock_entry_count_addr()));
@@ -1184,7 +1184,7 @@ int MacroAssembler::biased_locking_enter(Register lock_reg,
   // If the low three bits in the xor result aren't clear, that means
   // the prototype header is no longer biased and we have to revoke
   // the bias on this object.
-  testptr(header_reg, markOopDesc::biased_lock_mask_in_place);
+  testptr(header_reg, markOop::biased_lock_mask_in_place);
   jcc(Assembler::notZero, try_revoke_bias);
 
   // Biasing is still enabled for this data type. See whether the
@@ -1196,7 +1196,7 @@ int MacroAssembler::biased_locking_enter(Register lock_reg,
   // that the current epoch is invalid in order to do this because
   // otherwise the manipulations it performs on the mark word are
   // illegal.
-  testptr(header_reg, markOopDesc::epoch_mask_in_place);
+  testptr(header_reg, markOop::epoch_mask_in_place);
   jccb(Assembler::notZero, try_rebias);
 
   // The epoch of the current bias is still valid but we know nothing
@@ -1207,7 +1207,7 @@ int MacroAssembler::biased_locking_enter(Register lock_reg,
   // don't accidentally blow away another thread's valid bias.
   NOT_LP64( movptr(swap_reg, saved_mark_addr); )
   andptr(swap_reg,
-         markOopDesc::biased_lock_mask_in_place | markOopDesc::age_mask_in_place | markOopDesc::epoch_mask_in_place);
+         markOop::biased_lock_mask_in_place | markOop::age_mask_in_place | markOop::epoch_mask_in_place);
 #ifdef _LP64
   movptr(tmp_reg, swap_reg);
   orptr(tmp_reg, r15_thread);
@@ -1307,8 +1307,8 @@ void MacroAssembler::biased_locking_exit(Register obj_reg, Register temp_reg, La
   // lock, the object could not be rebiased toward another thread, so
   // the bias bit would be clear.
   movptr(temp_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-  andptr(temp_reg, markOopDesc::biased_lock_mask_in_place);
-  cmpptr(temp_reg, markOopDesc::biased_lock_pattern);
+  andptr(temp_reg, markOop::biased_lock_mask_in_place);
+  cmpptr(temp_reg, markOop::biased_lock_pattern);
   jcc(Assembler::equal, done);
 }
 
@@ -1499,7 +1499,7 @@ void MacroAssembler::rtm_stack_locking(Register objReg, Register tmpReg, Registe
     bind(L_rtm_retry);
   }
   movptr(tmpReg, Address(objReg, oopDesc::mark_offset_in_bytes()));
-  testptr(tmpReg, markOopDesc::monitor_value);  // inflated vs stack-locked|neutral|biased
+  testptr(tmpReg, markOop::monitor_value);  // inflated vs stack-locked|neutral|biased
   jcc(Assembler::notZero, IsInflated);
 
   if (PrintPreciseRTMLockingStatistics || profile_rtm) {
@@ -1514,8 +1514,8 @@ void MacroAssembler::rtm_stack_locking(Register objReg, Register tmpReg, Registe
   }
   xbegin(L_on_abort);
   movptr(tmpReg, Address(objReg, oopDesc::mark_offset_in_bytes()));       // fetch markword
-  andptr(tmpReg, markOopDesc::biased_lock_mask_in_place); // look at 3 lock bits
-  cmpptr(tmpReg, markOopDesc::unlocked_value);            // bits = 001 unlocked
+  andptr(tmpReg, markOop::biased_lock_mask_in_place); // look at 3 lock bits
+  cmpptr(tmpReg, markOop::unlocked_value);            // bits = 001 unlocked
   jcc(Assembler::equal, DONE_LABEL);        // all done if unlocked
 
   Register abort_status_Reg = tmpReg; // status of abort is stored in RAX
@@ -1541,7 +1541,7 @@ void MacroAssembler::rtm_stack_locking(Register objReg, Register tmpReg, Registe
 // Use RTM for inflating locks
 // inputs: objReg (object to lock)
 //         boxReg (on-stack box address (displaced header location) - KILLED)
-//         tmpReg (ObjectMonitor address + markOopDesc::monitor_value)
+//         tmpReg (ObjectMonitor address + markOop::monitor_value)
 void MacroAssembler::rtm_inflated_locking(Register objReg, Register boxReg, Register tmpReg,
                                           Register scrReg, Register retry_on_busy_count_Reg,
                                           Register retry_on_abort_count_Reg,
@@ -1555,7 +1555,7 @@ void MacroAssembler::rtm_inflated_locking(Register objReg, Register boxReg, Regi
   int owner_offset = OM_OFFSET_NO_MONITOR_VALUE_TAG(owner);
 
   // Without cast to int32_t a movptr will destroy r10 which is typically obj
-  movptr(Address(boxReg, 0), (int32_t)intptr_t(markOopDesc::unused_mark()));
+  movptr(Address(boxReg, 0), (int32_t)intptr_t(markOop::unused_mark().value()));
   movptr(boxReg, tmpReg); // Save ObjectMonitor address
 
   if (RTMRetryCount > 0) {
@@ -1724,9 +1724,9 @@ void MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmpReg
     atomic_incl(ExternalAddress((address)counters->total_entry_count_addr()), scrReg);
   }
   if (EmitSync & 1) {
-      // set box->dhw = markOopDesc::unused_mark()
+      // set box->dhw = markOop::unused_mark()
       // Force all sync thru slow-path: slow_enter() and slow_exit()
-      movptr (Address(boxReg, 0), (int32_t)intptr_t(markOopDesc::unused_mark()));
+      movptr (Address(boxReg, 0), (int32_t)intptr_t(markOop::unused_mark().value()));
       cmpptr (rsp, (int32_t)NULL_WORD);
   } else {
     // Possible cases that we'll encounter in fast_lock
@@ -1768,11 +1768,11 @@ void MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmpReg
 #endif // INCLUDE_RTM_OPT
 
     movptr(tmpReg, Address(objReg, oopDesc::mark_offset_in_bytes()));          // [FETCH]
-    testptr(tmpReg, markOopDesc::monitor_value); // inflated vs stack-locked|neutral|biased
+    testptr(tmpReg, markOop::monitor_value); // inflated vs stack-locked|neutral|biased
     jccb(Assembler::notZero, IsInflated);
 
     // Attempt stack-locking ...
-    orptr (tmpReg, markOopDesc::unlocked_value);
+    orptr (tmpReg, markOop::unlocked_value);
     movptr(Address(boxReg, 0), tmpReg);          // Anticipate successful CAS
     if (os::is_MP()) {
       lock();
@@ -1798,7 +1798,7 @@ void MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmpReg
     jmp(DONE_LABEL);
 
     bind(IsInflated);
-    // The object is inflated. tmpReg contains pointer to ObjectMonitor* + markOopDesc::monitor_value
+    // The object is inflated. tmpReg contains pointer to ObjectMonitor* + markOop::monitor_value
 
 #if INCLUDE_RTM_OPT
     // Use the same RTM locking code in 32- and 64-bit VM.
@@ -1813,7 +1813,7 @@ void MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmpReg
 
     // boxReg refers to the on-stack BasicLock in the current frame.
     // We'd like to write:
-    //   set box->_displaced_header = markOopDesc::unused_mark().  Any non-0 value suffices.
+    //   set box->_displaced_header = markOop::unused_mark().  Any non-0 value suffices.
     // This is convenient but results a ST-before-CAS penalty.  The following CAS suffers
     // additional latency as we have another ST in the store buffer that must drain.
 
@@ -1878,7 +1878,7 @@ void MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmpReg
        //   Invariant: m->_recursions should already be 0, so we don't need to explicitly set it.
        // Intentional fall-through into DONE_LABEL ...
     } else {
-       movptr(Address(boxReg, 0), intptr_t(markOopDesc::unused_mark()));  // results in ST-before-CAS penalty
+       movptr(Address(boxReg, 0), intptr_t(markOop::unused_mark()));  // results in ST-before-CAS penalty
        movptr(boxReg, tmpReg);
 
        // Using a prefetchw helps avoid later RTS->RTO upgrades and cache probes
@@ -1923,9 +1923,9 @@ void MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmpReg
       lock();
     }
     cmpxchgptr(r15_thread, Address(scrReg, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)));
-    // Unconditionally set box->_displaced_header = markOopDesc::unused_mark().
+    // Unconditionally set box->_displaced_header = markOop::unused_mark().
     // Without cast to int32_t movptr will destroy r10 which is typically obj.
-    movptr(Address(boxReg, 0), (int32_t)intptr_t(markOopDesc::unused_mark()));
+    movptr(Address(boxReg, 0), (int32_t)intptr_t(markOop::unused_mark().value()));
     // Intentional fall-through into DONE_LABEL ...
     // Propagate ICC.ZF from CAS above into DONE_LABEL.
 #endif // _LP64
@@ -1999,8 +1999,8 @@ void MacroAssembler::fast_unlock(Register objReg, Register boxReg, Register tmpR
       assert(!UseBiasedLocking, "Biased locking is not supported with RTM locking");
       Label L_regular_unlock;
       movptr(tmpReg, Address(objReg, oopDesc::mark_offset_in_bytes()));           // fetch markword
-      andptr(tmpReg, markOopDesc::biased_lock_mask_in_place); // look at 3 lock bits
-      cmpptr(tmpReg, markOopDesc::unlocked_value);            // bits = 001 unlocked
+      andptr(tmpReg, markOop::biased_lock_mask_in_place); // look at 3 lock bits
+      cmpptr(tmpReg, markOop::unlocked_value);            // bits = 001 unlocked
       jccb(Assembler::notEqual, L_regular_unlock);  // if !HLE RegularLock
       xend();                                       // otherwise end...
       jmp(DONE_LABEL);                              // ... and we're done
@@ -2011,7 +2011,7 @@ void MacroAssembler::fast_unlock(Register objReg, Register boxReg, Register tmpR
     cmpptr(Address(boxReg, 0), (int32_t)NULL_WORD); // Examine the displaced header
     jcc   (Assembler::zero, DONE_LABEL);            // 0 indicates recursive stack-lock
     movptr(tmpReg, Address(objReg, oopDesc::mark_offset_in_bytes()));             // Examine the object's markword
-    testptr(tmpReg, markOopDesc::monitor_value);    // Inflated?
+    testptr(tmpReg, markOop::monitor_value);    // Inflated?
     jccb  (Assembler::zero, Stacked);
 
     // It's inflated.

--- a/src/hotspot/cpu/x86/sharedRuntime_x86.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86.cpp
@@ -59,12 +59,12 @@ void SharedRuntime::inline_check_hashcode_from_object_header(MacroAssembler* mas
   __ movptr(result, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
 
   // check if locked
-  __ testptr(result, markOopDesc::unlocked_value);
+  __ testptr(result, markOop::unlocked_value);
   __ jcc(Assembler::zero, slowCase);
 
   if (UseBiasedLocking) {
     // Check if biased and fall through to runtime if so
-    __ testptr(result, markOopDesc::biased_lock_bit_in_place);
+    __ testptr(result, markOop::biased_lock_bit_in_place);
     __ jcc(Assembler::notZero, slowCase);
   }
 
@@ -73,16 +73,16 @@ void SharedRuntime::inline_check_hashcode_from_object_header(MacroAssembler* mas
   // Read the header and build a mask to get its hash field.
   // Depend on hash_mask being at most 32 bits and avoid the use of hash_mask_in_place
   // because it could be larger than 32 bits in a 64-bit vm. See markOop.hpp.
-  __ shrptr(result, markOopDesc::hash_shift);
-  __ andptr(result, markOopDesc::hash_mask);
+  __ shrptr(result, markOop::hash_shift);
+  __ andptr(result, markOop::hash_mask);
 #else
-  __ andptr(result, markOopDesc::hash_mask_in_place);
+  __ andptr(result, markOop::hash_mask_in_place);
 #endif //_LP64
 
   // test if hashCode exists
   __ jcc(Assembler::zero, slowCase);
 #ifndef _LP64
-  __ shrptr(result, markOopDesc::hash_shift);
+  __ shrptr(result, markOop::hash_shift);
 #endif
   __ ret(0);
   __ bind(slowCase);

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -4103,7 +4103,7 @@ void TemplateTable::_new() {
       __ movptr(Address(rax, oopDesc::mark_offset_in_bytes ()), rbx);
     } else {
       __ movptr(Address(rax, oopDesc::mark_offset_in_bytes ()),
-                (intptr_t)markOopDesc::prototype()); // header
+                (intptr_t)markOop::prototype().value()); // header
       __ pop(rcx);   // get saved klass back in the register.
     }
 #ifdef _LP64

--- a/src/hotspot/cpu/zero/cppInterpreter_zero.cpp
+++ b/src/hotspot/cpu/zero/cppInterpreter_zero.cpp
@@ -274,7 +274,7 @@ int CppInterpreter::native_entry(Method* method, intptr_t UNUSED, TRAPS) {
   if (method->is_synchronized()) {
     monitor = (BasicObjectLock*) istate->stack_base();
     oop lockee = monitor->obj();
-    markOop disp = lockee->mark()->set_unlocked();
+    markOop disp = lockee->mark().set_unlocked();
 
     monitor->lock()->set_displaced_header(disp);
     if (lockee->cas_set_mark((markOop)monitor, disp) != disp) {
@@ -421,7 +421,7 @@ int CppInterpreter::native_entry(Method* method, intptr_t UNUSED, TRAPS) {
     monitor->set_obj(NULL);
 
     if (header != NULL) {
-      markOop old_header = markOopDesc::encode(lock);
+      markOop old_header = markOop::encode(lock);
       if (rcvr->cas_set_mark(header, old_header) != old_header) {
         monitor->set_obj(rcvr); {
           HandleMark hm(thread);

--- a/src/hotspot/share/classfile/altHashing.cpp
+++ b/src/hotspot/share/classfile/altHashing.cpp
@@ -52,8 +52,8 @@
 // objects.  We don't want to call the synchronizer hash code to install
 // this value because it may safepoint.
 static intptr_t object_hash(Klass* k) {
-  intptr_t hc = k->java_mirror()->mark()->hash();
-  return hc != markOopDesc::no_hash ? hc : os::random();
+  intptr_t hc = k->java_mirror()->mark().hash();
+  return hc != markOop::no_hash ? hc : os::random();
 }
 
 // Seed value used for each alternative hash calculated.

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -2181,7 +2181,7 @@ void SystemDictionary::update_dictionary(unsigned int d_hash,
       // NOTE that we must only do this when the class is initally
       // defined, not each time it is referenced from a new class loader
       if (k->class_loader() == class_loader()) {
-        k->set_prototype_header(markOopDesc::biased_locking_prototype());
+        k->set_prototype_header(markOop::biased_locking_prototype());
       }
     }
 

--- a/src/hotspot/share/gc/cms/parOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/cms/parOopClosures.inline.hpp
@@ -47,7 +47,7 @@ template <class T> inline void ParScanWeakRefClosure::do_oop_work(T* p) {
     OrderAccess::loadload();
     markOop m = obj->mark_raw();
     oop new_obj;
-    if (m->is_marked()) { // Contains forwarding pointer.
+    if (m.is_marked()) { // Contains forwarding pointer.
       new_obj = ParNewGeneration::real_forwardee(obj);
     } else {
       size_t obj_sz = obj->size_given_klass(objK);
@@ -112,7 +112,7 @@ inline void ParScanClosure::do_oop_work(T* p,
       OrderAccess::loadload();
       markOop m = obj->mark_raw();
       oop new_obj;
-      if (m->is_marked()) { // Contains forwarding pointer.
+      if (m.is_marked()) { // Contains forwarding pointer.
         new_obj = ParNewGeneration::real_forwardee(obj);
         RawAccess<IS_NOT_NULL>::oop_store(p, new_obj);
         log_develop_trace(gc, scavenge)("{%s %s ( " PTR_FORMAT " ) " PTR_FORMAT " -> " PTR_FORMAT " (%d)}",

--- a/src/hotspot/share/gc/cms/promotionInfo.cpp
+++ b/src/hotspot/share/gc/cms/promotionInfo.cpp
@@ -95,13 +95,13 @@ void PromotionInfo::track(PromotedObject* trackOop, Klass* klassOfOop) {
   // make a copy of header as it may need to be spooled
   markOop mark = oop(trackOop)->mark_raw();
   trackOop->clear_next();
-  if (mark->must_be_preserved_for_cms_scavenge(klassOfOop)) {
+  if (mark.must_be_preserved_for_cms_scavenge(klassOfOop)) {
     // save non-prototypical header, and mark oop
     saveDisplacedHeader(mark);
     trackOop->setDisplacedMark();
   } else {
     // we'd like to assert something like the following:
-    // assert(mark == markOopDesc::prototype(), "consistency check");
+    // assert(mark == markOop::prototype(), "consistency check");
     // ... but the above won't work because the age bits have not (yet) been
     // cleared. The remainder of the check would be identical to the
     // condition checked in must_be_preserved() above, so we don't really

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -116,11 +116,11 @@ void G1FullGCCompactionPoint::forward(oop object, size_t size) {
     } else {
       // Make sure object has the correct mark-word set or that it will be
       // fixed when restoring the preserved marks.
-      assert(object->mark_raw() == markOopDesc::prototype_for_object(object) || // Correct mark
-             object->mark_raw()->must_be_preserved(object) || // Will be restored by PreservedMarksSet
+      assert(object->mark_raw() == markOop::prototype_for_object(object) || // Correct mark
+             object->mark_raw().must_be_preserved(object) || // Will be restored by PreservedMarksSet
              (UseBiasedLocking && object->has_bias_pattern_raw()), // Will be restored by BiasedLocking
              "should have correct prototype obj: " PTR_FORMAT " mark: " PTR_FORMAT " prototype: " PTR_FORMAT,
-             p2i(object), p2i(object->mark_raw()), p2i(markOopDesc::prototype_for_object(object)));
+             p2i(object), p2i(object->mark_raw()), p2i(markOop::prototype_for_object(object)));
     }
     assert(object->forwardee() == NULL, "should be forwarded to NULL");
   }

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -51,7 +51,7 @@ inline bool G1FullGCMarker::mark_object(oop obj) {
 
   // Marked by us, preserve if needed.
   markOop mark = obj->mark_raw();
-  if (mark->must_be_preserved(obj) &&
+  if (mark.must_be_preserved(obj) &&
       !G1ArchiveAllocator::is_open_archive_object(obj)) {
     preserved_stack()->push(obj, mark);
   }

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
@@ -76,11 +76,11 @@ template <class T> inline void G1AdjustClosure::adjust_pointer(T* p) {
   oop forwardee = obj->forwardee();
   if (forwardee == NULL) {
     // Not forwarded, return current reference.
-    assert(obj->mark_raw() == markOopDesc::prototype_for_object(obj) || // Correct mark
-           obj->mark_raw()->must_be_preserved(obj) || // Will be restored by PreservedMarksSet
+    assert(obj->mark_raw() == markOop::prototype_for_object(obj) || // Correct mark
+           obj->mark_raw().must_be_preserved(obj) || // Will be restored by PreservedMarksSet
            (UseBiasedLocking && obj->has_bias_pattern_raw()), // Will be restored by BiasedLocking
            "Must have correct prototype or be preserved, obj: " PTR_FORMAT ", mark: " PTR_FORMAT ", prototype: " PTR_FORMAT,
-           p2i(obj), p2i(obj->mark_raw()), p2i(markOopDesc::prototype_for_object(obj)));
+           p2i(obj), p2i(obj->mark_raw()), p2i(markOop::prototype_for_object(obj)));
     return;
   }
 

--- a/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -250,8 +250,8 @@ void G1ParCopyClosure<barrier, do_mark_object>::do_oop_work(T* p) {
   if (state.is_in_cset()) {
     oop forwardee;
     markOop m = obj->mark_raw();
-    if (m->is_marked()) {
-      forwardee = (oop) m->decode_pointer();
+    if (m.is_marked()) {
+      forwardee = (oop) m.decode_pointer();
     } else {
       forwardee = _par_scan_state->copy_to_survivor_space(state, obj, m);
     }

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -188,8 +188,8 @@ HeapWord* G1ParScanThreadState::allocate_in_next_plab(InCSetState const state,
 
 InCSetState G1ParScanThreadState::next_state(InCSetState const state, markOop const m, uint& age) {
   if (state.is_young()) {
-    age = !m->has_displaced_mark_helper() ? m->age()
-                                          : m->displaced_mark_helper()->age();
+    age = !m.has_displaced_mark_helper() ? m.age()
+                                          : m.displaced_mark_helper().age();
     if (age < _tenuring_threshold) {
       return state;
     }
@@ -271,18 +271,18 @@ oop G1ParScanThreadState::copy_to_survivor_space(InCSetState const state,
     Copy::aligned_disjoint_words((HeapWord*) old, obj_ptr, word_sz);
 
     if (dest_state.is_young()) {
-      if (age < markOopDesc::max_age) {
+      if (age < markOop::max_age) {
         age++;
       }
-      if (old_mark->has_displaced_mark_helper()) {
+      if (old_mark.has_displaced_mark_helper()) {
         // In this case, we have to install the mark word first,
         // otherwise obj looks to be forwarded (the old mark word,
         // which contains the forward pointer, was copied)
         obj->set_mark_raw(old_mark);
-        markOop new_mark = old_mark->displaced_mark_helper()->set_age(age);
-        old_mark->set_displaced_mark_helper(new_mark);
+        markOop new_mark = old_mark.displaced_mark_helper().set_age(age);
+        old_mark.set_displaced_mark_helper(new_mark);
       } else {
-        obj->set_mark_raw(old_mark->set_age(age));
+        obj->set_mark_raw(old_mark.set_age(age));
       }
       _age_table.add(age, word_sz);
     } else {

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
@@ -42,8 +42,8 @@ template <class T> void G1ParScanThreadState::do_oop_evac(T* p) {
   const InCSetState in_cset_state = _g1h->in_cset_state(obj);
   if (in_cset_state.is_in_cset()) {
     markOop m = obj->mark_raw();
-    if (m->is_marked()) {
-      obj = (oop) m->decode_pointer();
+    if (m.is_marked()) {
+      obj = (oop) m.decode_pointer();
     } else {
       obj = copy_to_survivor_space(in_cset_state, obj, m);
     }

--- a/src/hotspot/share/gc/parallel/psMarkSweepDecorator.cpp
+++ b/src/hotspot/share/gc/parallel/psMarkSweepDecorator.cpp
@@ -113,8 +113,8 @@ void PSMarkSweepDecorator::precompact() {
   const intx interval = PrefetchScanIntervalInBytes;
 
   while (q < t) {
-    assert(oop(q)->mark_raw()->is_marked() || oop(q)->mark_raw()->is_unlocked() ||
-           oop(q)->mark_raw()->has_bias_pattern(),
+    assert(oop(q)->mark_raw().is_marked() || oop(q)->mark_raw().is_unlocked() ||
+           oop(q)->mark_raw().has_bias_pattern(),
            "these are the only valid states during a mark sweep");
     if (oop(q)->is_gc_marked()) {
       /* prefetch beyond q */
@@ -259,7 +259,7 @@ bool PSMarkSweepDecorator::insert_deadspace(size_t& allowed_deadspace_words,
   if (allowed_deadspace_words >= deadlength) {
     allowed_deadspace_words -= deadlength;
     CollectedHeap::fill_with_object(q, deadlength);
-    oop(q)->set_mark_raw(oop(q)->mark_raw()->set_marked());
+    oop(q)->set_mark_raw(oop(q)->mark_raw().set_marked());
     assert((int) deadlength == oop(q)->size(), "bad filler object size");
     // Recall that we required "q == compaction_top".
     return true;
@@ -350,7 +350,7 @@ void PSMarkSweepDecorator::compact(bool mangle_free_space ) {
       q = t;
     } else {
       // $$$ Funky
-      q = (HeapWord*) oop(_first_dead)->mark_raw()->decode_pointer();
+      q = (HeapWord*) oop(_first_dead)->mark_raw().decode_pointer();
     }
   }
 
@@ -361,7 +361,7 @@ void PSMarkSweepDecorator::compact(bool mangle_free_space ) {
     if (!oop(q)->is_gc_marked()) {
       // mark is pointer to next marked oop
       debug_only(prev_q = q);
-      q = (HeapWord*) oop(q)->mark_raw()->decode_pointer();
+      q = (HeapWord*) oop(q)->mark_raw().decode_pointer();
       assert(q > prev_q, "we should be moving forward through memory");
     } else {
       // prefetch beyond q

--- a/src/hotspot/share/gc/parallel/psPromotionLAB.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionLAB.cpp
@@ -82,7 +82,7 @@ void PSPromotionLAB::flush() {
   // so they can always fill with an array.
   HeapWord* tlab_end = end() + filler_header_size;
   typeArrayOop filler_oop = (typeArrayOop) top();
-  filler_oop->set_mark_raw(markOopDesc::prototype());
+  filler_oop->set_mark_raw(markOop::prototype());
   filler_oop->set_klass(Universe::intArrayKlassObj());
   const size_t array_length =
     pointer_delta(tlab_end, top()) - typeArrayOopDesc::header_size(T_INT);

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -119,13 +119,13 @@ inline oop PSPromotionManager::copy_to_survivor_space(oop o) {
   markOop test_mark = o->mark_raw();
 
   // The same test as "o->is_forwarded()"
-  if (!test_mark->is_marked()) {
+  if (!test_mark.is_marked()) {
     bool new_obj_is_tenured = false;
     size_t new_obj_size = o->size();
 
     // Find the objects age, MT safe.
-    uint age = (test_mark->has_displaced_mark_helper() /* o->has_displaced_mark() */) ?
-      test_mark->displaced_mark_helper()->age() : test_mark->age();
+    uint age = (test_mark.has_displaced_mark_helper() /* o->has_displaced_mark() */) ?
+      test_mark.displaced_mark_helper().age() : test_mark.age();
 
     if (!promote_immediately) {
       // Try allocating obj in to-space (unless too old)

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -276,7 +276,7 @@ bool PSScavenge::invoke_no_policy() {
   heap->print_heap_before_gc();
   heap->trace_heap_before_gc(&_gc_tracer);
 
-  assert(!NeverTenure || _tenuring_threshold == markOopDesc::max_age + 1, "Sanity");
+  assert(!NeverTenure || _tenuring_threshold == markOop::max_age + 1, "Sanity");
   assert(!AlwaysTenure || _tenuring_threshold == 0, "Sanity");
 
   // Fill in TLABs
@@ -728,8 +728,8 @@ void PSScavenge::initialize() {
   // Arguments must have been parsed
 
   if (AlwaysTenure || NeverTenure) {
-    assert(MaxTenuringThreshold == 0 || MaxTenuringThreshold == markOopDesc::max_age + 1,
-           "MaxTenuringThreshold should be 0 or markOopDesc::max_age + 1, but is %d", (int) MaxTenuringThreshold);
+    assert(MaxTenuringThreshold == 0 || MaxTenuringThreshold == markOop::max_age + 1,
+           "MaxTenuringThreshold should be 0 or markOop::max_age + 1, but is %d", (int) MaxTenuringThreshold);
     _tenuring_threshold = MaxTenuringThreshold;
   } else {
     // We want to smooth out our startup times for the AdaptiveSizePolicy

--- a/src/hotspot/share/gc/serial/markSweep.cpp
+++ b/src/hotspot/share/gc/serial/markSweep.cpp
@@ -131,7 +131,7 @@ template <class T> inline void MarkSweep::follow_root(T* p) {
   T heap_oop = RawAccess<>::oop_load(p);
   if (!CompressedOops::is_null(heap_oop)) {
     oop obj = CompressedOops::decode_not_null(heap_oop);
-    if (!obj->mark_raw()->is_marked()) {
+    if (!obj->mark_raw().is_marked()) {
       mark_object(obj);
       follow_object(obj);
     }

--- a/src/hotspot/share/gc/serial/markSweep.inline.hpp
+++ b/src/hotspot/share/gc/serial/markSweep.inline.hpp
@@ -39,9 +39,9 @@ inline void MarkSweep::mark_object(oop obj) {
   // some marks may contain information we need to preserve so we store them away
   // and overwrite the mark.  We'll restore it at the end of markSweep.
   markOop mark = obj->mark_raw();
-  obj->set_mark_raw(markOopDesc::prototype()->set_marked());
+  obj->set_mark_raw(markOop::prototype().set_marked());
 
-  if (mark->must_be_preserved(obj)) {
+  if (mark.must_be_preserved(obj)) {
     preserve_mark(obj, mark);
   }
 }
@@ -50,7 +50,7 @@ template <class T> inline void MarkSweep::mark_and_push(T* p) {
   T heap_oop = RawAccess<>::oop_load(p);
   if (!CompressedOops::is_null(heap_oop)) {
     oop obj = CompressedOops::decode_not_null(heap_oop);
-    if (!obj->mark_raw()->is_marked()) {
+    if (!obj->mark_raw().is_marked()) {
       mark_object(obj);
       _marking_stack.push(obj);
     }
@@ -79,11 +79,11 @@ template <class T> inline void MarkSweep::adjust_pointer(T* p) {
     oop obj = CompressedOops::decode_not_null(heap_oop);
     assert(Universe::heap()->is_in(obj), "should be in heap");
 
-    oop new_obj = oop(obj->mark_raw()->decode_pointer());
+    oop new_obj = oop(obj->mark_raw().decode_pointer());
 
     assert(new_obj != NULL ||                         // is forwarding ptr?
-           obj->mark_raw() == markOopDesc::prototype() || // not gc marked?
-           (UseBiasedLocking && obj->mark_raw()->has_bias_pattern()),
+           obj->mark_raw() == markOop::prototype() || // not gc marked?
+           (UseBiasedLocking && obj->mark_raw().has_bias_pattern()),
            // not gc marked?
            "should be forwarded");
 

--- a/src/hotspot/share/gc/shared/ageTable.cpp
+++ b/src/hotspot/share/gc/shared/ageTable.cpp
@@ -79,8 +79,8 @@ uint AgeTable::compute_tenuring_threshold(size_t desired_survivor_size) {
   uint result;
 
   if (AlwaysTenure || NeverTenure) {
-    assert(MaxTenuringThreshold == 0 || MaxTenuringThreshold == markOopDesc::max_age + 1,
-           "MaxTenuringThreshold should be 0 or markOopDesc::max_age + 1, but is " UINTX_FORMAT, MaxTenuringThreshold);
+    assert(MaxTenuringThreshold == 0 || MaxTenuringThreshold == markOop::max_age + 1,
+           "MaxTenuringThreshold should be 0 or markOop::max_age + 1, but is " UINTX_FORMAT, MaxTenuringThreshold);
     result = MaxTenuringThreshold;
   } else {
     size_t total = 0;

--- a/src/hotspot/share/gc/shared/ageTable.hpp
+++ b/src/hotspot/share/gc/shared/ageTable.hpp
@@ -41,7 +41,7 @@ class AgeTable {
 
  public:
   // constants
-  enum { table_size = markOopDesc::max_age + 1 };
+  enum { table_size = markOop::max_age + 1 };
 
   // instance variables
   size_t sizes[table_size];

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -816,12 +816,12 @@
                                                                             \
   product(uintx, MaxTenuringThreshold,    15,                               \
           "Maximum value for tenuring threshold")                           \
-          range(0, markOopDesc::max_age + 1)                                \
+          range(0, markOop::max_age + 1)                                \
           constraint(MaxTenuringThresholdConstraintFunc,AfterErgo)          \
                                                                             \
   product(uintx, InitialTenuringThreshold,    7,                            \
           "Initial value for tenuring threshold")                           \
-          range(0, markOopDesc::max_age + 1)                                \
+          range(0, markOop::max_age + 1)                                \
           constraint(InitialTenuringThresholdConstraintFunc,AfterErgo)      \
                                                                             \
   product(uintx, TargetSurvivorRatio,    50,                                \

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -400,7 +400,7 @@ oop MemAllocator::finish(HeapWord* mem) const {
     oopDesc::set_mark_raw(mem, _klass->prototype_header());
   } else {
     // May be bootstrapping
-    oopDesc::set_mark_raw(mem, markOopDesc::prototype());
+    oopDesc::set_mark_raw(mem, markOop::prototype());
   }
   // Need a release store to ensure array/class length, mark word, and
   // object zeroing are visible before setting the klass non-NULL, for

--- a/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
@@ -31,7 +31,7 @@
 #include "utilities/stack.inline.hpp"
 
 inline bool PreservedMarks::should_preserve_mark(oop obj, markOop m) const {
-  return m->must_be_preserved_for_promotion_failure(obj);
+  return m.must_be_preserved_for_promotion_failure(obj);
 }
 
 inline void PreservedMarks::push(oop obj, markOop m) {

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -651,14 +651,14 @@ void ContiguousSpace::allocate_temporary_filler(int factor) {
     // allocate uninitialized int array
     typeArrayOop t = (typeArrayOop) allocate(size);
     assert(t != NULL, "allocation should succeed");
-    t->set_mark_raw(markOopDesc::prototype());
+    t->set_mark_raw(markOop::prototype());
     t->set_klass(Universe::intArrayKlassObj());
     t->set_length((int)length);
   } else {
     assert(size == CollectedHeap::min_fill_size(),
            "size for smallest fake object doesn't match");
     instanceOop obj = (instanceOop) allocate(size);
-    obj->set_mark_raw(markOopDesc::prototype());
+    obj->set_mark_raw(markOop::prototype());
     obj->set_klass_gap(0);
     obj->set_klass(SystemDictionary::Object_klass());
   }

--- a/src/hotspot/share/gc/shared/space.inline.hpp
+++ b/src/hotspot/share/gc/shared/space.inline.hpp
@@ -118,7 +118,7 @@ public:
       _allowed_deadspace_words -= dead_length;
       CollectedHeap::fill_with_object(dead_start, dead_length);
       oop obj = oop(dead_start);
-      obj->set_mark_raw(obj->mark_raw()->set_marked());
+      obj->set_mark_raw(obj->mark_raw().set_marked());
 
       assert(dead_length == (size_t)obj->size(), "bad filler object size");
       log_develop_trace(gc, compaction)("Inserting object to dead space: " PTR_FORMAT ", " PTR_FORMAT ", " SIZE_FORMAT "b",
@@ -165,8 +165,8 @@ inline void CompactibleSpace::scan_and_forward(SpaceType* space, CompactPoint* c
 
   while (cur_obj < scan_limit) {
     assert(!space->scanned_block_is_obj(cur_obj) ||
-           oop(cur_obj)->mark_raw()->is_marked() || oop(cur_obj)->mark_raw()->is_unlocked() ||
-           oop(cur_obj)->mark_raw()->has_bias_pattern(),
+           oop(cur_obj)->mark_raw().is_marked() || oop(cur_obj)->mark_raw().is_unlocked() ||
+           oop(cur_obj)->mark_raw().has_bias_pattern(),
            "these are the only valid states during a mark sweep");
     if (space->scanned_block_is_obj(cur_obj) && oop(cur_obj)->is_gc_marked()) {
       // prefetch beyond cur_obj

--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -60,7 +60,7 @@ void ShenandoahAsserts::print_obj(ShenandoahMessageBuffer& msg, oop obj) {
   r->print_on(&ss);
 
   stringStream mw_ss;
-  obj->mark()->print_on(&mw_ss);
+  obj->mark().print_on(&mw_ss);
 
   ShenandoahMarkingContext* const ctx = heap->marking_context();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahForwarding.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahForwarding.inline.hpp
@@ -40,8 +40,8 @@ inline HeapWord* ShenandoahForwarding::get_forwardee_raw_unchecked(oop obj) {
   // fwdptr. That object is still not forwarded, and we need to return
   // the object itself.
   markOop mark = obj->mark_raw();
-  if (mark->is_marked()) {
-    HeapWord* fwdptr = (HeapWord*) mark->clear_lock_bits();
+  if (mark.is_marked()) {
+    HeapWord* fwdptr = (HeapWord*) mark.clear_lock_bits();
     if (fwdptr != NULL) {
       return fwdptr;
     }
@@ -55,8 +55,8 @@ inline oop ShenandoahForwarding::get_forwardee_mutator(oop obj) {
   assert(Thread::current()->is_Java_thread(), "Must be a mutator thread");
 
   markOop mark = obj->mark_raw();
-  if (mark->is_marked()) {
-    HeapWord* fwdptr = (HeapWord*)mark->clear_lock_bits();
+  if (mark.is_marked()) {
+    HeapWord* fwdptr = (HeapWord*)mark.clear_lock_bits();
     assert(fwdptr != NULL, "Forwarding pointer is never null here");
     return oop(fwdptr);
   } else {
@@ -70,21 +70,21 @@ inline oop ShenandoahForwarding::get_forwardee(oop obj) {
 }
 
 inline bool ShenandoahForwarding::is_forwarded(oop obj) {
-  return obj->mark_raw()->is_marked();
+  return obj->mark_raw().is_marked();
 }
 
 inline oop ShenandoahForwarding::try_update_forwardee(oop obj, oop update) {
   markOop old_mark = obj->mark_raw();
-  if (old_mark->is_marked()) {
-    return (oop) old_mark->clear_lock_bits();
+  if (old_mark.is_marked()) {
+    return (oop) old_mark.clear_lock_bits();
   }
 
-  markOop new_mark = markOopDesc::encode_pointer_as_mark(update);
+  markOop new_mark = markOop::encode_pointer_as_mark(update);
   markOop prev_mark = obj->cas_set_mark_raw(new_mark, old_mark);
   if (prev_mark == old_mark) {
     return update;
   } else {
-    return (oop) prev_mark->clear_lock_bits();
+    return (oop) prev_mark.clear_lock_bits();
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahStringDedup.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahStringDedup.cpp
@@ -50,14 +50,14 @@ void ShenandoahStringDedup::enqueue_candidate(oop java_string) {
     const markOop mark = java_string->mark();
 
     // Having/had displaced header, too risk to deal with them, skip
-    if (mark == markOopDesc::INFLATING() || mark->has_displaced_mark_helper()) {
+    if (mark == markOop::INFLATING() || mark.has_displaced_mark_helper()) {
       return;
     }
 
     // Increase string age and enqueue it when it rearches age threshold
-    markOop new_mark = mark->incr_age();
+    markOop new_mark = mark.incr_age();
     if (mark == java_string->cas_set_mark(new_mark, mark)) {
-      if (mark->age() == StringDeduplicationAgeThreshold) {
+      if (mark.age() == StringDeduplicationAgeThreshold) {
         StringDedupQueue::push(ShenandoahWorkerSession::worker_id(), java_string);
       }
     }

--- a/src/hotspot/share/interpreter/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/bytecodeInterpreter.cpp
@@ -665,17 +665,17 @@ BytecodeInterpreter::run(interpreterState istate) {
         BasicObjectLock* mon = &istate->monitor_base()[-1];
         mon->set_obj(rcvr);
         bool success = false;
-        uintptr_t epoch_mask_in_place = (uintptr_t)markOopDesc::epoch_mask_in_place;
+        uintptr_t epoch_mask_in_place = (uintptr_t)markOop::epoch_mask_in_place;
         markOop mark = rcvr->mark();
-        intptr_t hash = (intptr_t) markOopDesc::no_hash;
+        intptr_t hash = (intptr_t) markOop::no_hash;
         // Implies UseBiasedLocking.
-        if (mark->has_bias_pattern()) {
+        if (mark.has_bias_pattern()) {
           uintptr_t thread_ident;
           uintptr_t anticipated_bias_locking_value;
           thread_ident = (uintptr_t)istate->thread();
           anticipated_bias_locking_value =
             (((uintptr_t)rcvr->klass()->prototype_header() | thread_ident) ^ (uintptr_t)mark) &
-            ~((uintptr_t) markOopDesc::age_mask_in_place);
+            ~((uintptr_t) markOop::age_mask_in_place);
 
           if (anticipated_bias_locking_value == 0) {
             // Already biased towards this thread, nothing to do.
@@ -683,10 +683,10 @@ BytecodeInterpreter::run(interpreterState istate) {
               (* BiasedLocking::biased_lock_entry_count_addr())++;
             }
             success = true;
-          } else if ((anticipated_bias_locking_value & markOopDesc::biased_lock_mask_in_place) != 0) {
+          } else if ((anticipated_bias_locking_value & markOop::biased_lock_mask_in_place) != 0) {
             // Try to revoke bias.
             markOop header = rcvr->klass()->prototype_header();
-            if (hash != markOopDesc::no_hash) {
+            if (hash != markOop::no_hash) {
               header = header->copy_set_hash(hash);
             }
             if (rcvr->cas_set_mark(header, mark) == mark) {
@@ -696,7 +696,7 @@ BytecodeInterpreter::run(interpreterState istate) {
           } else if ((anticipated_bias_locking_value & epoch_mask_in_place) != 0) {
             // Try to rebias.
             markOop new_header = (markOop) ( (intptr_t) rcvr->klass()->prototype_header() | thread_ident);
-            if (hash != markOopDesc::no_hash) {
+            if (hash != markOop::no_hash) {
               new_header = new_header->copy_set_hash(hash);
             }
             if (rcvr->cas_set_mark(new_header, mark) == mark) {
@@ -710,9 +710,9 @@ BytecodeInterpreter::run(interpreterState istate) {
           } else {
             // Try to bias towards thread in case object is anonymously biased.
             markOop header = (markOop) ((uintptr_t) mark &
-                                        ((uintptr_t)markOopDesc::biased_lock_mask_in_place |
-                                         (uintptr_t)markOopDesc::age_mask_in_place | epoch_mask_in_place));
-            if (hash != markOopDesc::no_hash) {
+                                        ((uintptr_t)markOop::biased_lock_mask_in_place |
+                                         (uintptr_t)markOop::age_mask_in_place | epoch_mask_in_place));
+            if (hash != markOop::no_hash) {
               header = header->copy_set_hash(hash);
             }
             markOop new_header = (markOop) ((uintptr_t) header | thread_ident);
@@ -731,7 +731,7 @@ BytecodeInterpreter::run(interpreterState istate) {
 
         // Traditional lightweight locking.
         if (!success) {
-          markOop displaced = rcvr->mark()->set_unlocked();
+          markOop displaced = rcvr->mark().set_unlocked();
           mon->lock()->set_displaced_header(displaced);
           bool call_vm = UseHeavyMonitors;
           if (call_vm || rcvr->cas_set_mark((markOop)mon, displaced) != displaced) {
@@ -850,18 +850,18 @@ BytecodeInterpreter::run(interpreterState istate) {
       assert(entry->obj() == NULL, "Frame manager didn't allocate the monitor");
       entry->set_obj(lockee);
       bool success = false;
-      uintptr_t epoch_mask_in_place = (uintptr_t)markOopDesc::epoch_mask_in_place;
+      uintptr_t epoch_mask_in_place = (uintptr_t)markOop::epoch_mask_in_place;
 
       markOop mark = lockee->mark();
-      intptr_t hash = (intptr_t) markOopDesc::no_hash;
+      intptr_t hash = (intptr_t) markOop::no_hash;
       // implies UseBiasedLocking
-      if (mark->has_bias_pattern()) {
+      if (mark.has_bias_pattern()) {
         uintptr_t thread_ident;
         uintptr_t anticipated_bias_locking_value;
         thread_ident = (uintptr_t)istate->thread();
         anticipated_bias_locking_value =
           (((uintptr_t)lockee->klass()->prototype_header() | thread_ident) ^ (uintptr_t)mark) &
-          ~((uintptr_t) markOopDesc::age_mask_in_place);
+          ~((uintptr_t) markOop::age_mask_in_place);
 
         if  (anticipated_bias_locking_value == 0) {
           // already biased towards this thread, nothing to do
@@ -869,10 +869,10 @@ BytecodeInterpreter::run(interpreterState istate) {
             (* BiasedLocking::biased_lock_entry_count_addr())++;
           }
           success = true;
-        } else if ((anticipated_bias_locking_value & markOopDesc::biased_lock_mask_in_place) != 0) {
+        } else if ((anticipated_bias_locking_value & markOop::biased_lock_mask_in_place) != 0) {
           // try revoke bias
           markOop header = lockee->klass()->prototype_header();
-          if (hash != markOopDesc::no_hash) {
+          if (hash != markOop::no_hash) {
             header = header->copy_set_hash(hash);
           }
           if (lockee->cas_set_mark(header, mark) == mark) {
@@ -883,7 +883,7 @@ BytecodeInterpreter::run(interpreterState istate) {
         } else if ((anticipated_bias_locking_value & epoch_mask_in_place) !=0) {
           // try rebias
           markOop new_header = (markOop) ( (intptr_t) lockee->klass()->prototype_header() | thread_ident);
-          if (hash != markOopDesc::no_hash) {
+          if (hash != markOop::no_hash) {
                 new_header = new_header->copy_set_hash(hash);
           }
           if (lockee->cas_set_mark(new_header, mark) == mark) {
@@ -896,9 +896,9 @@ BytecodeInterpreter::run(interpreterState istate) {
           success = true;
         } else {
           // try to bias towards thread in case object is anonymously biased
-          markOop header = (markOop) ((uintptr_t) mark & ((uintptr_t)markOopDesc::biased_lock_mask_in_place |
-                                                          (uintptr_t)markOopDesc::age_mask_in_place | epoch_mask_in_place));
-          if (hash != markOopDesc::no_hash) {
+          markOop header = (markOop) ((uintptr_t) mark & ((uintptr_t)markOop::biased_lock_mask_in_place |
+                                                          (uintptr_t)markOop::age_mask_in_place | epoch_mask_in_place));
+          if (hash != markOop::no_hash) {
             header = header->copy_set_hash(hash);
           }
           markOop new_header = (markOop) ((uintptr_t) header | thread_ident);
@@ -917,7 +917,7 @@ BytecodeInterpreter::run(interpreterState istate) {
 
       // traditional lightweight locking
       if (!success) {
-        markOop displaced = lockee->mark()->set_unlocked();
+        markOop displaced = lockee->mark().set_unlocked();
         entry->lock()->set_displaced_header(displaced);
         bool call_vm = UseHeavyMonitors;
         if (call_vm || lockee->cas_set_mark((markOop)entry, displaced) != displaced) {
@@ -1790,18 +1790,18 @@ run:
         if (entry != NULL) {
           entry->set_obj(lockee);
           int success = false;
-          uintptr_t epoch_mask_in_place = (uintptr_t)markOopDesc::epoch_mask_in_place;
+          uintptr_t epoch_mask_in_place = (uintptr_t)markOop::epoch_mask_in_place;
 
           markOop mark = lockee->mark();
-          intptr_t hash = (intptr_t) markOopDesc::no_hash;
+          intptr_t hash = (intptr_t) markOop::no_hash;
           // implies UseBiasedLocking
-          if (mark->has_bias_pattern()) {
+          if (mark.has_bias_pattern()) {
             uintptr_t thread_ident;
             uintptr_t anticipated_bias_locking_value;
             thread_ident = (uintptr_t)istate->thread();
             anticipated_bias_locking_value =
               (((uintptr_t)lockee->klass()->prototype_header() | thread_ident) ^ (uintptr_t)mark) &
-              ~((uintptr_t) markOopDesc::age_mask_in_place);
+              ~((uintptr_t) markOop::age_mask_in_place);
 
             if  (anticipated_bias_locking_value == 0) {
               // already biased towards this thread, nothing to do
@@ -1810,10 +1810,10 @@ run:
               }
               success = true;
             }
-            else if ((anticipated_bias_locking_value & markOopDesc::biased_lock_mask_in_place) != 0) {
+            else if ((anticipated_bias_locking_value & markOop::biased_lock_mask_in_place) != 0) {
               // try revoke bias
               markOop header = lockee->klass()->prototype_header();
-              if (hash != markOopDesc::no_hash) {
+              if (hash != markOop::no_hash) {
                 header = header->copy_set_hash(hash);
               }
               if (lockee->cas_set_mark(header, mark) == mark) {
@@ -1824,7 +1824,7 @@ run:
             else if ((anticipated_bias_locking_value & epoch_mask_in_place) !=0) {
               // try rebias
               markOop new_header = (markOop) ( (intptr_t) lockee->klass()->prototype_header() | thread_ident);
-              if (hash != markOopDesc::no_hash) {
+              if (hash != markOop::no_hash) {
                 new_header = new_header->copy_set_hash(hash);
               }
               if (lockee->cas_set_mark(new_header, mark) == mark) {
@@ -1838,10 +1838,10 @@ run:
             }
             else {
               // try to bias towards thread in case object is anonymously biased
-              markOop header = (markOop) ((uintptr_t) mark & ((uintptr_t)markOopDesc::biased_lock_mask_in_place |
-                                                              (uintptr_t)markOopDesc::age_mask_in_place |
+              markOop header = (markOop) ((uintptr_t) mark & ((uintptr_t)markOop::biased_lock_mask_in_place |
+                                                              (uintptr_t)markOop::age_mask_in_place |
                                                               epoch_mask_in_place));
-              if (hash != markOopDesc::no_hash) {
+              if (hash != markOop::no_hash) {
                 header = header->copy_set_hash(hash);
               }
               markOop new_header = (markOop) ((uintptr_t) header | thread_ident);
@@ -1860,7 +1860,7 @@ run:
 
           // traditional lightweight locking
           if (!success) {
-            markOop displaced = lockee->mark()->set_unlocked();
+            markOop displaced = lockee->mark().set_unlocked();
             entry->lock()->set_displaced_header(displaced);
             bool call_vm = UseHeavyMonitors;
             if (call_vm || lockee->cas_set_mark((markOop)entry, displaced) != displaced) {
@@ -1891,11 +1891,11 @@ run:
             BasicLock* lock = most_recent->lock();
             markOop header = lock->displaced_header();
             most_recent->set_obj(NULL);
-            if (!lockee->mark()->has_bias_pattern()) {
+            if (!lockee->mark().has_bias_pattern()) {
               bool call_vm = UseHeavyMonitors;
               // If it isn't recursive we either must swap old header or call the runtime
               if (header != NULL || call_vm) {
-                markOop old_header = markOopDesc::encode(lock);
+                markOop old_header = markOop::encode(lock);
                 if (call_vm || lockee->cas_set_mark(header, old_header) != old_header) {
                   // restore object for the slow case
                   most_recent->set_obj(lockee);
@@ -2181,7 +2181,7 @@ run:
               if (UseBiasedLocking) {
                 result->set_mark(ik->prototype_header());
               } else {
-                result->set_mark(markOopDesc::prototype());
+                result->set_mark(markOop::prototype());
               }
               result->set_klass_gap(0);
               result->set_klass(ik);
@@ -3031,10 +3031,10 @@ run:
           markOop header = lock->displaced_header();
           end->set_obj(NULL);
 
-          if (!lockee->mark()->has_bias_pattern()) {
+          if (!lockee->mark().has_bias_pattern()) {
             // If it isn't recursive we either must swap old header or call the runtime
             if (header != NULL) {
-              markOop old_header = markOopDesc::encode(lock);
+              markOop old_header = markOop::encode(lock);
               if (lockee->cas_set_mark(header, old_header) != old_header) {
                 // restore object for the slow case
                 end->set_obj(lockee);
@@ -3106,11 +3106,11 @@ run:
             markOop header = lock->displaced_header();
             base->set_obj(NULL);
 
-            if (!rcvr->mark()->has_bias_pattern()) {
+            if (!rcvr->mark().has_bias_pattern()) {
               base->set_obj(NULL);
               // If it isn't recursive we either must swap old header or call the runtime
               if (header != NULL) {
-                markOop old_header = markOopDesc::encode(lock);
+                markOop old_header = markOop::encode(lock);
                 if (rcvr->cas_set_mark(header, old_header) != old_header) {
                   // restore object for the slow case
                   base->set_obj(rcvr);

--- a/src/hotspot/share/jfr/leakprofiler/chains/bfsClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bfsClosure.cpp
@@ -131,7 +131,7 @@ void BFSClosure::closure_impl(const oop* reference, const oop pointee) {
   if (!_mark_bits->is_marked(pointee)) {
     _mark_bits->mark_obj(pointee);
     // is the pointee a sample object?
-    if (NULL == pointee->mark()) {
+    if (NULL == pointee->mark().to_pointer()) {
       add_chain(reference, pointee);
     }
 

--- a/src/hotspot/share/jfr/leakprofiler/chains/dfsClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/dfsClosure.cpp
@@ -121,7 +121,7 @@ void DFSClosure::closure_impl(const oop* reference, const oop pointee) {
   assert(_mark_bits->is_marked(pointee), "invariant");
 
   // is the pointee a sample object?
-  if (NULL == pointee->mark()) {
+  if (NULL == pointee->mark().to_pointer()) {
     add_chain();
   }
 

--- a/src/hotspot/share/jfr/leakprofiler/chains/edgeStore.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/edgeStore.cpp
@@ -237,8 +237,8 @@ StoredEdge* EdgeStore::associate_leak_context_with_candidate(const Edge* edge) {
   StoredEdge* const leak_context_edge = put(edge->reference());
   oop sample_object = edge->pointee();
   assert(sample_object != NULL, "invariant");
-  assert(NULL == sample_object->mark(), "invariant");
-  sample_object->set_mark(markOop(leak_context_edge));
+  assert(NULL == sample_object->mark().to_pointer(), "invariant");
+  sample_object->set_mark(markOop::from_pointer(leak_context_edge));
   return leak_context_edge;
 }
 

--- a/src/hotspot/share/jfr/leakprofiler/chains/edgeUtils.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/edgeUtils.cpp
@@ -36,7 +36,7 @@
 #include "runtime/handles.inline.hpp"
 
 bool EdgeUtils::is_leak_edge(const Edge& edge) {
-  return (const Edge*)edge.pointee()->mark() == &edge;
+  return (const Edge*)edge.pointee()->mark().to_pointer() == &edge;
 }
 
 static bool is_static_field(const oop ref_owner, const InstanceKlass* ik, int offset) {

--- a/src/hotspot/share/jfr/leakprofiler/chains/objectSampleMarker.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/objectSampleMarker.hpp
@@ -45,7 +45,7 @@ class ObjectSampleMarker : public StackObj {
                         const markOop mark_oop) : _obj(obj),
                                                   _mark_oop(mark_oop) {}
    public:
-    ObjectSampleMarkOop() : _obj(NULL), _mark_oop(NULL) {}
+    ObjectSampleMarkOop() : _obj(NULL), _mark_oop(markOop::zero()) {}
   };
 
   GrowableArray<ObjectSampleMarkOop>* _store;
@@ -72,8 +72,8 @@ class ObjectSampleMarker : public StackObj {
     // This is an "impossible" state during a safepoint,
     // hence we will use it to quickly identify sample objects
     // during the reachability search from gc roots.
-    assert(NULL == markOopDesc::INFLATING(), "invariant");
-    obj->set_mark(markOopDesc::INFLATING());
+    assert(NULL == markOop::INFLATING(), "invariant");
+    obj->set_mark(markOop::INFLATING());
     assert(NULL == obj->mark(), "invariant");
   }
 };

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.cpp
@@ -111,7 +111,7 @@ void EventEmitter::write_event(const ObjectSample* sample, EdgeStore* edge_store
   traceid gc_root_id = 0;
   const Edge* edge = NULL;
   if (SafepointSynchronize::is_at_safepoint()) {
-    edge = (const Edge*)(*object_addr)->mark();
+    edge = (const Edge*)(*object_addr)->mark().to_pointer();
   }
   if (edge == NULL) {
     // In order to dump out a representation of the event

--- a/src/hotspot/share/jfr/leakprofiler/utilities/saveRestore.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/saveRestore.cpp
@@ -27,7 +27,7 @@
 #include "jfr/leakprofiler/utilities/saveRestore.hpp"
 #include "oops/oop.inline.hpp"
 
-MarkOopContext::MarkOopContext() : _obj(NULL), _mark_oop(NULL) {}
+MarkOopContext::MarkOopContext() : _obj(NULL), _mark_oop(markOop::zero()) {}
 
 MarkOopContext::MarkOopContext(const oop obj) : _obj(obj), _mark_oop(obj->mark()) {
   assert(_obj->mark() == _mark_oop, "invariant");
@@ -36,8 +36,8 @@ MarkOopContext::MarkOopContext(const oop obj) : _obj(obj), _mark_oop(obj->mark()
   // This is an "impossible" state during a safepoint,
   // hence we will use it to quickly identify objects
   // during the reachability search from gc roots.
-  assert(NULL == markOopDesc::INFLATING(), "invariant");
-  _obj->set_mark(markOopDesc::INFLATING());
+  assert(NULL == markOop::INFLATING(), "invariant");
+  _obj->set_mark(markOop::INFLATING());
   assert(NULL == obj->mark(), "invariant");
 }
 
@@ -48,7 +48,7 @@ MarkOopContext::~MarkOopContext() {
   }
 }
 
-MarkOopContext::MarkOopContext(const MarkOopContext& rhs) : _obj(NULL), _mark_oop(NULL) {
+MarkOopContext::MarkOopContext(const MarkOopContext& rhs) : _obj(NULL), _mark_oop(markOop::zero()) {
   swap(const_cast<MarkOopContext&>(rhs));
 }
 

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -566,7 +566,7 @@
   declare_constant(Klass::_lh_array_tag_type_value)                       \
   declare_constant(Klass::_lh_array_tag_obj_value)                        \
                                                                           \
-  declare_constant(markOopDesc::no_hash)                                  \
+  declare_constant(markOop::no_hash)                                  \
                                                                           \
   declare_constant(Method::_caller_sensitive)                             \
   declare_constant(Method::_force_inline)                                 \
@@ -598,19 +598,19 @@
   declare_constant(InvocationCounter::count_increment)                    \
   declare_constant(InvocationCounter::count_shift)                        \
                                                                           \
-  declare_constant(markOopDesc::hash_shift)                               \
+  declare_constant(markOop::hash_shift)                               \
                                                                           \
-  declare_constant(markOopDesc::biased_lock_mask_in_place)                \
-  declare_constant(markOopDesc::age_mask_in_place)                        \
-  declare_constant(markOopDesc::epoch_mask_in_place)                      \
-  declare_constant(markOopDesc::hash_mask)                                \
-  declare_constant(markOopDesc::hash_mask_in_place)                       \
+  declare_constant(markOop::biased_lock_mask_in_place)                \
+  declare_constant(markOop::age_mask_in_place)                        \
+  declare_constant(markOop::epoch_mask_in_place)                      \
+  declare_constant(markOop::hash_mask)                                \
+  declare_constant(markOop::hash_mask_in_place)                       \
                                                                           \
-  declare_constant(markOopDesc::unlocked_value)                           \
-  declare_constant(markOopDesc::biased_lock_pattern)                      \
+  declare_constant(markOop::unlocked_value)                           \
+  declare_constant(markOop::biased_lock_pattern)                      \
                                                                           \
-  declare_constant(markOopDesc::no_hash_in_place)                         \
-  declare_constant(markOopDesc::no_lock_in_place)                         \
+  declare_constant(markOop::no_hash_in_place)                         \
+  declare_constant(markOop::no_lock_in_place)                         \
 
 #define VM_ADDRESSES(declare_address, declare_preprocessor_address, declare_function) \
   declare_function(SharedRuntime::register_finalizer)                     \

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1898,7 +1898,7 @@ void MetaspaceShared::dump_open_archive_heap_objects(
 }
 
 unsigned MetaspaceShared::obj_hash(oop const& p) {
-  assert(!p->mark()->has_bias_pattern(),
+  assert(!p->mark().has_bias_pattern(),
          "this object should never have been locked");  // so identity_hash won't safepoin
   unsigned hash = (unsigned)p->identity_hash();
   return hash;

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -1310,12 +1310,12 @@ uintptr_t Universe::verify_oop_bits() {
 }
 
 uintptr_t Universe::verify_mark_mask() {
-  return markOopDesc::lock_mask_in_place;
+  return markOop::lock_mask_in_place;
 }
 
 uintptr_t Universe::verify_mark_bits() {
   intptr_t mask = verify_mark_mask();
-  intptr_t bits = (intptr_t)markOopDesc::prototype();
+  intptr_t bits = (intptr_t)markOop::prototype();
   assert((bits & ~mask) == 0, "no stray header bits");
   return bits;
 }

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -627,9 +627,9 @@ ReservedHeapSpace::ReservedHeapSpace(size_t size, size_t alignment, bool large, 
     initialize(size, alignment, large, NULL, false);
   }
 
-  assert(markOopDesc::encode_pointer_as_mark(_base)->decode_pointer() == _base,
+  assert(markOop::encode_pointer_as_mark(_base)->decode_pointer() == _base,
          "area must be distinguishable from marks for mark-sweep");
-  assert(markOopDesc::encode_pointer_as_mark(&_base[size])->decode_pointer() == &_base[size],
+  assert(markOop::encode_pointer_as_mark(&_base[size])->decode_pointer() == &_base[size],
          "area must be distinguishable from marks for mark-sweep");
 
   if (base() != NULL) {

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -195,7 +195,7 @@ void* Klass::operator new(size_t size, ClassLoaderData* loader_data, size_t word
 // Need to set the _java_mirror field explicitly to not hit an assert that the field
 // should be NULL before setting it.
 Klass::Klass(KlassID id) : _id(id),
-                           _prototype_header(markOopDesc::prototype()),
+                           _prototype_header(markOop::prototype()),
                            _shared_class_path_index(-1),
                            _java_mirror(NULL) {
   CDS_ONLY(_shared_class_flags = 0;)
@@ -682,7 +682,7 @@ void Klass::oop_print_on(oop obj, outputStream* st) {
 
   if (WizardMode) {
      // print header
-     obj->mark()->print_on(st);
+     obj->mark().print_on(st);
   }
 
   // print class

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -28,6 +28,7 @@
 #include "classfile/classLoaderData.hpp"
 #include "memory/iterator.hpp"
 #include "memory/memRegion.hpp"
+#include "oops/markOop.hpp"
 #include "oops/metadata.hpp"
 #include "oops/oop.hpp"
 #include "oops/oopHandle.hpp"

--- a/src/hotspot/share/oops/markOop.cpp
+++ b/src/hotspot/share/oops/markOop.cpp
@@ -27,7 +27,7 @@
 #include "runtime/thread.inline.hpp"
 #include "runtime/objectMonitor.inline.hpp"
 
-void markOopDesc::print_on(outputStream* st) const {
+void markOop::print_on(outputStream* st) const {
   if (is_marked()) {
     st->print(" marked(" INTPTR_FORMAT ")", value());
   } else if (has_monitor()) {

--- a/src/hotspot/share/oops/markOop.inline.hpp
+++ b/src/hotspot/share/oops/markOop.inline.hpp
@@ -31,7 +31,7 @@
 #include "runtime/globals.hpp"
 
 // Should this header be preserved during GC (when biased locking is enabled)?
-inline bool markOopDesc::must_be_preserved_with_bias(oop obj_containing_mark) const {
+inline bool markOop::must_be_preserved_with_bias(oop obj_containing_mark) const {
   assert(UseBiasedLocking, "unexpected");
   if (has_bias_pattern()) {
     // Will reset bias at end of collection
@@ -39,7 +39,7 @@ inline bool markOopDesc::must_be_preserved_with_bias(oop obj_containing_mark) co
     return false;
   }
   markOop prototype_header = prototype_for_object(obj_containing_mark);
-  if (prototype_header->has_bias_pattern()) {
+  if (prototype_header.has_bias_pattern()) {
     // Individual instance which has its bias revoked; must return
     // true for correctness
     return true;
@@ -48,7 +48,7 @@ inline bool markOopDesc::must_be_preserved_with_bias(oop obj_containing_mark) co
 }
 
 // Should this header be preserved during GC?
-inline bool markOopDesc::must_be_preserved(oop obj_containing_mark) const {
+inline bool markOop::must_be_preserved(oop obj_containing_mark) const {
   if (!UseBiasedLocking)
     return (!is_unlocked() || !has_no_hash());
   return must_be_preserved_with_bias(obj_containing_mark);
@@ -56,7 +56,7 @@ inline bool markOopDesc::must_be_preserved(oop obj_containing_mark) const {
 
 // Should this header be preserved in the case of a promotion failure
 // during scavenge (when biased locking is enabled)?
-inline bool markOopDesc::must_be_preserved_with_bias_for_promotion_failure(oop obj_containing_mark) const {
+inline bool markOop::must_be_preserved_with_bias_for_promotion_failure(oop obj_containing_mark) const {
   assert(UseBiasedLocking, "unexpected");
   // We don't explicitly save off the mark words of biased and
   // currently-locked objects during scavenges, so if during a
@@ -68,7 +68,7 @@ inline bool markOopDesc::must_be_preserved_with_bias_for_promotion_failure(oop o
   // BiasedLocking::preserve_marks() / restore_marks() in the middle
   // of a scavenge when a promotion failure has first been detected.
   if (has_bias_pattern() ||
-      prototype_for_object(obj_containing_mark)->has_bias_pattern()) {
+      prototype_for_object(obj_containing_mark).has_bias_pattern()) {
     return true;
   }
   return (!is_unlocked() || !has_no_hash());
@@ -76,7 +76,7 @@ inline bool markOopDesc::must_be_preserved_with_bias_for_promotion_failure(oop o
 
 // Should this header be preserved in the case of a promotion failure
 // during scavenge?
-inline bool markOopDesc::must_be_preserved_for_promotion_failure(oop obj_containing_mark) const {
+inline bool markOop::must_be_preserved_for_promotion_failure(oop obj_containing_mark) const {
   if (!UseBiasedLocking)
     return (!is_unlocked() || !has_no_hash());
   return must_be_preserved_with_bias_for_promotion_failure(obj_containing_mark);
@@ -85,11 +85,11 @@ inline bool markOopDesc::must_be_preserved_for_promotion_failure(oop obj_contain
 
 // Same as must_be_preserved_with_bias_for_promotion_failure() except that
 // it takes a Klass* argument, instead of the object of which this is the mark word.
-inline bool markOopDesc::must_be_preserved_with_bias_for_cms_scavenge(Klass* klass_of_obj_containing_mark) const {
+inline bool markOop::must_be_preserved_with_bias_for_cms_scavenge(Klass* klass_of_obj_containing_mark) const {
   assert(UseBiasedLocking, "unexpected");
   // CMS scavenges preserve mark words in similar fashion to promotion failures; see above
   if (has_bias_pattern() ||
-      klass_of_obj_containing_mark->prototype_header()->has_bias_pattern()) {
+      klass_of_obj_containing_mark->prototype_header().has_bias_pattern()) {
     return true;
   }
   return (!is_unlocked() || !has_no_hash());
@@ -97,16 +97,16 @@ inline bool markOopDesc::must_be_preserved_with_bias_for_cms_scavenge(Klass* kla
 
 // Same as must_be_preserved_for_promotion_failure() except that
 // it takes a Klass* argument, instead of the object of which this is the mark word.
-inline bool markOopDesc::must_be_preserved_for_cms_scavenge(Klass* klass_of_obj_containing_mark) const {
+inline bool markOop::must_be_preserved_for_cms_scavenge(Klass* klass_of_obj_containing_mark) const {
   if (!UseBiasedLocking)
     return (!is_unlocked() || !has_no_hash());
   return must_be_preserved_with_bias_for_cms_scavenge(klass_of_obj_containing_mark);
 }
 
-inline markOop markOopDesc::prototype_for_object(oop obj) {
+inline markOop markOop::prototype_for_object(oop obj) {
 #ifdef ASSERT
   markOop prototype_header = obj->klass()->prototype_header();
-  assert(prototype_header == prototype() || prototype_header->has_bias_pattern(), "corrupt prototype header");
+  assert(prototype_header == prototype() || prototype_header.has_bias_pattern(), "corrupt prototype header");
 #endif
   return obj->klass()->prototype_header();
 }

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -130,7 +130,7 @@ bool oopDesc::is_oop(oop obj, bool ignore_mark_word) {
   if (ignore_mark_word) {
     return true;
   }
-  if (obj->mark_raw() != NULL) {
+  if (obj->mark_raw().value() != 0) {
     return true;
   }
   return !SafepointSynchronize::is_at_safepoint();

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -28,6 +28,7 @@
 #include "memory/iterator.hpp"
 #include "memory/memRegion.hpp"
 #include "oops/access.hpp"
+#include "oops/markOop.hpp"
 #include "oops/metadata.hpp"
 #include "runtime/atomic.hpp"
 #include "utilities/macros.hpp"

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -44,23 +44,24 @@
 // We need a separate file to avoid circular references
 
 markOop  oopDesc::mark()      const {
-  return HeapAccess<MO_VOLATILE>::load_at(as_oop(), mark_offset_in_bytes());
+  uintptr_t v = HeapAccess<MO_VOLATILE>::load_at(as_oop(), mark_offset_in_bytes());
+  return markOop(v);
 }
 
 markOop  oopDesc::mark_raw()  const {
-  return _mark;
+  return Atomic::load(&_mark);;
 }
 
 markOop* oopDesc::mark_addr_raw() const {
   return (markOop*) &_mark;
 }
 
-void oopDesc::set_mark(volatile markOop m) {
-  HeapAccess<MO_VOLATILE>::store_at(as_oop(), mark_offset_in_bytes(), m);
+void oopDesc::set_mark(markOop m) {
+  HeapAccess<MO_VOLATILE>::store_at(as_oop(), mark_offset_in_bytes(), m.value());
 }
 
-void oopDesc::set_mark_raw(volatile markOop m) {
-  _mark = m;
+void oopDesc::set_mark_raw(markOop m) {
+  Atomic::store(m, &_mark);
 }
 
 void oopDesc::set_mark_raw(HeapWord* mem, markOop m) {
@@ -68,11 +69,12 @@ void oopDesc::set_mark_raw(HeapWord* mem, markOop m) {
 }
 
 void oopDesc::release_set_mark(markOop m) {
-  HeapAccess<MO_RELEASE>::store_at(as_oop(), mark_offset_in_bytes(), m);
+  HeapAccess<MO_RELEASE>::store_at(as_oop(), mark_offset_in_bytes(), m.value());
 }
 
 markOop oopDesc::cas_set_mark(markOop new_mark, markOop old_mark) {
-  return HeapAccess<>::atomic_cmpxchg_at(new_mark, as_oop(), mark_offset_in_bytes(), old_mark);
+  uintptr_t v = HeapAccess<>::atomic_cmpxchg_at(new_mark.value(), as_oop(), mark_offset_in_bytes(), old_mark.value());
+  return markOop(v);
 }
 
 markOop oopDesc::cas_set_mark_raw(markOop new_mark, markOop old_mark, atomic_memory_order order) {
@@ -80,11 +82,11 @@ markOop oopDesc::cas_set_mark_raw(markOop new_mark, markOop old_mark, atomic_mem
 }
 
 void oopDesc::init_mark() {
-  set_mark(markOopDesc::prototype_for_object(this));
+  set_mark(markOop::prototype_for_object(this));
 }
 
 void oopDesc::init_mark_raw() {
-  set_mark_raw(markOopDesc::prototype_for_object(this));
+  set_mark_raw(markOop::prototype_for_object(this));
 }
 
 Klass* oopDesc::klass() const {
@@ -318,31 +320,31 @@ inline jdouble oopDesc::double_field(int offset) const              { return Hea
 inline void    oopDesc::double_field_put(int offset, jdouble value) { HeapAccess<>::store_at(as_oop(), offset, value); }
 
 bool oopDesc::is_locked() const {
-  return mark()->is_locked();
+  return mark().is_locked();
 }
 
 bool oopDesc::is_unlocked() const {
-  return mark()->is_unlocked();
+  return mark().is_unlocked();
 }
 
 bool oopDesc::has_bias_pattern() const {
-  return mark()->has_bias_pattern();
+  return mark().has_bias_pattern();
 }
 
 bool oopDesc::has_bias_pattern_raw() const {
-  return mark_raw()->has_bias_pattern();
+  return mark_raw().has_bias_pattern();
 }
 
 // Used only for markSweep, scavenging
 bool oopDesc::is_gc_marked() const {
-  return mark_raw()->is_marked();
+  return mark_raw().is_marked();
 }
 
 // Used by scavengers
 bool oopDesc::is_forwarded() const {
   // The extra heap check is needed since the obj might be locked, in which case the
   // mark would point to a stack location and have the sentinel bit cleared
-  return mark_raw()->is_marked();
+  return mark_raw().is_marked();
 }
 
 // Used by scavengers
@@ -354,8 +356,8 @@ void oopDesc::forward_to(oop p) {
   assert(!MetaspaceShared::is_archive_object(oop(this)) &&
          !MetaspaceShared::is_archive_object(p),
          "forwarding archive object");
-  markOop m = markOopDesc::encode_pointer_as_mark(p);
-  assert(m->decode_pointer() == p, "encoding must be reversable");
+  markOop m = markOop::encode_pointer_as_mark(p);
+  assert(m.decode_pointer() == p, "encoding must be reversable");
   set_mark_raw(m);
 }
 
@@ -365,20 +367,20 @@ bool oopDesc::cas_forward_to(oop p, markOop compare, atomic_memory_order order) 
          "forwarding to something not aligned");
   assert(Universe::heap()->is_in_reserved(p),
          "forwarding to something not in heap");
-  markOop m = markOopDesc::encode_pointer_as_mark(p);
-  assert(m->decode_pointer() == p, "encoding must be reversable");
+  markOop m = markOop::encode_pointer_as_mark(p);
+  assert(m.decode_pointer() == p, "encoding must be reversable");
   return cas_set_mark_raw(m, compare, order) == compare;
 }
 
 oop oopDesc::forward_to_atomic(oop p, atomic_memory_order order) {
   markOop oldMark = mark_raw();
-  markOop forwardPtrMark = markOopDesc::encode_pointer_as_mark(p);
+  markOop forwardPtrMark = markOop::encode_pointer_as_mark(p);
   markOop curMark;
 
-  assert(forwardPtrMark->decode_pointer() == p, "encoding must be reversable");
+  assert(forwardPtrMark.decode_pointer() == p, "encoding must be reversable");
   assert(sizeof(markOop) == sizeof(intptr_t), "CAS below requires this.");
 
-  while (!oldMark->is_marked()) {
+  while (!oldMark.is_marked()) {
     curMark = cas_set_mark_raw(forwardPtrMark, oldMark, order);
     assert(is_forwarded(), "object should have been forwarded");
     if (curMark == oldMark) {
@@ -396,33 +398,32 @@ oop oopDesc::forward_to_atomic(oop p, atomic_memory_order order) {
 // The forwardee is used when copying during scavenge and mark-sweep.
 // It does need to clear the low two locking- and GC-related bits.
 oop oopDesc::forwardee() const {
-  return (oop) mark_raw()->decode_pointer();
+  return (oop) mark_raw().decode_pointer();
 }
 
 // Note that the forwardee is not the same thing as the displaced_mark.
 // The forwardee is used when copying during scavenge and mark-sweep.
 // It does need to clear the low two locking- and GC-related bits.
 oop oopDesc::forwardee_acquire() const {
-  markOop m = OrderAccess::load_acquire(&_mark);
-  return (oop) m->decode_pointer();
+  return (oop) OrderAccess::load_acquire(&_mark).decode_pointer();
 }
 
 // The following method needs to be MT safe.
 uint oopDesc::age() const {
   assert(!is_forwarded(), "Attempt to read age from forwarded mark");
   if (has_displaced_mark_raw()) {
-    return displaced_mark_raw()->age();
+    return displaced_mark_raw().age();
   } else {
-    return mark_raw()->age();
+    return mark_raw().age();
   }
 }
 
 void oopDesc::incr_age() {
   assert(!is_forwarded(), "Attempt to increment age of forwarded mark");
   if (has_displaced_mark_raw()) {
-    set_displaced_mark_raw(displaced_mark_raw()->incr_age());
+    set_displaced_mark_raw(displaced_mark_raw().incr_age());
   } else {
-    set_mark_raw(mark_raw()->incr_age());
+    set_mark_raw(mark_raw().incr_age());
   }
 }
 
@@ -489,25 +490,25 @@ intptr_t oopDesc::identity_hash() {
   // Fast case; if the object is unlocked and the hash value is set, no locking is needed
   // Note: The mark must be read into local variable to avoid concurrent updates.
   markOop mrk = mark();
-  if (mrk->is_unlocked() && !mrk->has_no_hash()) {
-    return mrk->hash();
-  } else if (mrk->is_marked()) {
-    return mrk->hash();
+  if (mrk.is_unlocked() && !mrk.has_no_hash()) {
+    return mrk.hash();
+  } else if (mrk.is_marked()) {
+    return mrk.hash();
   } else {
     return slow_identity_hash();
   }
 }
 
 bool oopDesc::has_displaced_mark_raw() const {
-  return mark_raw()->has_displaced_mark_helper();
+  return mark_raw().has_displaced_mark_helper();
 }
 
 markOop oopDesc::displaced_mark_raw() const {
-  return mark_raw()->displaced_mark_helper();
+  return mark_raw().displaced_mark_helper();
 }
 
 void oopDesc::set_displaced_mark_raw(markOop m) {
-  mark_raw()->set_displaced_mark_helper(m);
+  mark_raw().set_displaced_mark_helper(m);
 }
 
 #endif // SHARE_VM_OOPS_OOP_INLINE_HPP

--- a/src/hotspot/share/oops/oopsHierarchy.hpp
+++ b/src/hotspot/share/oops/oopsHierarchy.hpp
@@ -40,7 +40,6 @@ typedef juint narrowOop; // Offset instead of address for an oop within a java o
 typedef juint  narrowKlass;
 
 typedef void* OopOrNarrowOopStar;
-typedef class   markOopDesc*                markOop;
 
 #ifndef CHECK_UNHANDLED_OOPS
 
@@ -120,7 +119,6 @@ public:
   operator oopDesc* () const volatile { return obj(); }
   operator intptr_t* () const         { return (intptr_t*)obj(); }
   operator PromotedObject* () const   { return (PromotedObject*)obj(); }
-  operator markOop () const volatile  { return markOop(obj()); }
   operator address   () const         { return (address)obj(); }
 
   // from javaCalls.cpp

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3961,9 +3961,9 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
   Node* header = make_load(no_ctrl, header_addr, TypeX_X, TypeX_X->basic_type(), MemNode::unordered);
 
   // Test the header to see if it is unlocked.
-  Node *lock_mask      = _gvn.MakeConX(markOopDesc::biased_lock_mask_in_place);
+  Node *lock_mask      = _gvn.MakeConX(markOop::biased_lock_mask_in_place);
   Node *lmasked_header = _gvn.transform(new AndXNode(header, lock_mask));
-  Node *unlocked_val   = _gvn.MakeConX(markOopDesc::unlocked_value);
+  Node *unlocked_val   = _gvn.MakeConX(markOop::unlocked_value);
   Node *chk_unlocked   = _gvn.transform(new CmpXNode( lmasked_header, unlocked_val));
   Node *test_unlocked  = _gvn.transform(new BoolNode( chk_unlocked, BoolTest::ne));
 
@@ -3973,8 +3973,8 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
   // We depend on hash_mask being at most 32 bits and avoid the use of
   // hash_mask_in_place because it could be larger than 32 bits in a 64-bit
   // vm: see markOop.hpp.
-  Node *hash_mask      = _gvn.intcon(markOopDesc::hash_mask);
-  Node *hash_shift     = _gvn.intcon(markOopDesc::hash_shift);
+  Node *hash_mask      = _gvn.intcon(markOop::hash_mask);
+  Node *hash_shift     = _gvn.intcon(markOop::hash_shift);
   Node *hshifted_header= _gvn.transform(new URShiftXNode(header, hash_shift));
   // This hack lets the hash bits live anywhere in the mark object now, as long
   // as the shift drops the relevant bits into the low 32 bits.  Note that
@@ -3983,7 +3983,7 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
   hshifted_header      = ConvX2I(hshifted_header);
   Node *hash_val       = _gvn.transform(new AndINode(hshifted_header, hash_mask));
 
-  Node *no_hash_val    = _gvn.intcon(markOopDesc::no_hash);
+  Node *no_hash_val    = _gvn.intcon(markOop::no_hash);
   Node *chk_assigned   = _gvn.transform(new CmpINode( hash_val, no_hash_val));
   Node *test_assigned  = _gvn.transform(new BoolNode( chk_assigned, BoolTest::eq));
 

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -1773,7 +1773,7 @@ PhaseMacroExpand::initialize_object(AllocateNode* alloc,
   if (UseBiasedLocking && (length == NULL)) {
     mark_node = make_load(control, rawmem, klass_node, in_bytes(Klass::prototype_header_offset()), TypeRawPtr::BOTTOM, T_ADDRESS);
   } else {
-    mark_node = makecon(TypeRawPtr::make((address)markOopDesc::prototype()));
+    mark_node = makecon(TypeRawPtr::make((address)markOop::prototype().value()));
   }
   rawmem = make_store(control, rawmem, object, oopDesc::mark_offset_in_bytes(), mark_node, T_ADDRESS);
 
@@ -2330,8 +2330,8 @@ void PhaseMacroExpand::expand_lock_node(LockNode *lock) {
 
     // Get fast path - mark word has the biased lock pattern.
     ctrl = opt_bits_test(ctrl, fast_lock_region, 1, mark_node,
-                         markOopDesc::biased_lock_mask_in_place,
-                         markOopDesc::biased_lock_pattern, true);
+                         markOop::biased_lock_mask_in_place,
+                         markOop::biased_lock_pattern, true);
     // fast_lock_region->in(1) is set to slow path.
     fast_lock_mem_phi->init_req(1, mem);
 
@@ -2360,7 +2360,7 @@ void PhaseMacroExpand::expand_lock_node(LockNode *lock) {
 
     // Get slow path - mark word does NOT match the value.
     Node* not_biased_ctrl =  opt_bits_test(ctrl, region, 3, x_node,
-                                      (~markOopDesc::age_mask_in_place), 0);
+                                      (~markOop::age_mask_in_place), 0);
     // region->in(3) is set to fast path - the object is biased to the current thread.
     mem_phi->init_req(3, mem);
 
@@ -2371,7 +2371,7 @@ void PhaseMacroExpand::expand_lock_node(LockNode *lock) {
     // First, check biased pattern.
     // Get fast path - _prototype_header has the same biased lock pattern.
     ctrl =  opt_bits_test(not_biased_ctrl, fast_lock_region, 2, x_node,
-                          markOopDesc::biased_lock_mask_in_place, 0, true);
+                          markOop::biased_lock_mask_in_place, 0, true);
 
     not_biased_ctrl = fast_lock_region->in(2); // Slow path
     // fast_lock_region->in(2) - the prototype header is no longer biased
@@ -2393,7 +2393,7 @@ void PhaseMacroExpand::expand_lock_node(LockNode *lock) {
 
     // Get slow path - mark word does NOT match epoch bits.
     Node* epoch_ctrl =  opt_bits_test(ctrl, rebiased_region, 1, x_node,
-                                      markOopDesc::epoch_mask_in_place, 0);
+                                      markOop::epoch_mask_in_place, 0);
     // The epoch of the current bias is not valid, attempt to rebias the object
     // toward the current thread.
     rebiased_region->init_req(2, epoch_ctrl);
@@ -2403,9 +2403,9 @@ void PhaseMacroExpand::expand_lock_node(LockNode *lock) {
     // rebiased_region->in(1) is set to fast path.
     // The epoch of the current bias is still valid but we know
     // nothing about the owner; it might be set or it might be clear.
-    Node* cmask   = MakeConX(markOopDesc::biased_lock_mask_in_place |
-                             markOopDesc::age_mask_in_place |
-                             markOopDesc::epoch_mask_in_place);
+    Node* cmask   = MakeConX(markOop::biased_lock_mask_in_place |
+                             markOop::age_mask_in_place |
+                             markOop::epoch_mask_in_place);
     Node* old = transform_later(new AndXNode(mark_node, cmask));
     cast_thread = transform_later(new CastP2XNode(ctrl, thread));
     Node* new_mark = transform_later(new OrXNode(cast_thread, old));
@@ -2520,8 +2520,8 @@ void PhaseMacroExpand::expand_unlock_node(UnlockNode *unlock) {
 
     Node* mark_node = make_load(ctrl, mem, obj, oopDesc::mark_offset_in_bytes(), TypeX_X, TypeX_X->basic_type());
     ctrl = opt_bits_test(ctrl, region, 3, mark_node,
-                         markOopDesc::biased_lock_mask_in_place,
-                         markOopDesc::biased_lock_pattern);
+                         markOop::biased_lock_mask_in_place,
+                         markOop::biased_lock_pattern);
   } else {
     region  = new RegionNode(3);
     // create a Phi for the memory state

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -965,16 +965,16 @@ JvmtiEnvBase::get_object_monitor_usage(JavaThread* calling_thread, jobject objec
     {
       markOop mark = hobj()->mark();
 
-      if (!mark->has_monitor()) {
+      if (!mark.has_monitor()) {
         // this object has a lightweight monitor
 
-        if (mark->has_locker()) {
-          owner = (address)mark->locker(); // save the address of the Lock word
+        if (mark.has_locker()) {
+          owner = (address)mark.locker(); // save the address of the Lock word
         }
         // implied else: no owner
       } else {
         // this object has a heavyweight monitor
-        mon = mark->monitor();
+        mon = mark.monitor();
 
         // The owner field of a heavyweight monitor may be NULL for no
         // owner, a JavaThread * or it may still be the address of the

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -1645,7 +1645,7 @@ class RestoreMarksClosure : public ObjectClosure {
   void do_object(oop o) {
     if (o != NULL) {
       markOop mark = o->mark();
-      if (mark->is_marked()) {
+      if (mark.is_marked()) {
         o->init_mark();
       }
     }
@@ -1723,23 +1723,23 @@ void ObjectMarker::done() {
 // mark an object
 inline void ObjectMarker::mark(oop o) {
   assert(Universe::heap()->is_in(o), "sanity check");
-  assert(!o->mark()->is_marked(), "should only mark an object once");
+  assert(!o->mark().is_marked(), "should only mark an object once");
 
   // object's mark word
   markOop mark = o->mark();
 
-  if (mark->must_be_preserved(o)) {
+  if (mark.must_be_preserved(o)) {
     _saved_mark_stack->push(mark);
     _saved_oop_stack->push(o);
   }
 
   // mark the object
-  o->set_mark(markOopDesc::prototype()->set_marked());
+  o->set_mark(markOop::prototype().set_marked());
 }
 
 // return true if object is marked
 inline bool ObjectMarker::visited(oop o) {
-  return o->mark()->is_marked();
+  return o->mark().is_marked();
 }
 
 // Stack allocated class to help ensure that ObjectMarker is used

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1666,7 +1666,7 @@ WB_END
 
 WB_ENTRY(jboolean, WB_IsMonitorInflated(JNIEnv* env, jobject wb, jobject obj))
   oop obj_oop = JNIHandles::resolve(obj);
-  return (jboolean) obj_oop->mark()->has_monitor();
+  return (jboolean) obj_oop->mark().has_monitor();
 WB_END
 
 WB_ENTRY(void, WB_ForceSafepoint(JNIEnv* env, jobject wb))

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2879,7 +2879,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       if (FLAG_SET_CMDLINE(bool, AlwaysTenure, false) != JVMFlag::SUCCESS) {
         return JNI_EINVAL;
       }
-      if (FLAG_SET_CMDLINE(uintx, MaxTenuringThreshold, markOopDesc::max_age + 1) != JVMFlag::SUCCESS) {
+      if (FLAG_SET_CMDLINE(uintx, MaxTenuringThreshold, markOop::max_age + 1) != JVMFlag::SUCCESS) {
         return JNI_EINVAL;
       }
     } else if (match_option(option, "-XX:+AlwaysTenure")) {

--- a/src/hotspot/share/runtime/basicLock.cpp
+++ b/src/hotspot/share/runtime/basicLock.cpp
@@ -29,8 +29,8 @@
 void BasicLock::print_on(outputStream* st) const {
   st->print("monitor");
   markOop moop = displaced_header();
-  if (moop != NULL)
-    moop->print_on(st);
+  if (moop.value() != 0)
+    moop.print_on(st);
 }
 
 void BasicLock::move_to(oop obj, BasicLock* dest) {
@@ -62,7 +62,7 @@ void BasicLock::move_to(oop obj, BasicLock* dest) {
   // is small (given the support for inflated fast-path locking in the fast_lock, etc)
   // we'll leave that optimization for another time.
 
-  if (displaced_header()->is_neutral()) {
+  if (displaced_header().is_neutral()) {
     ObjectSynchronizer::inflate_helper(obj);
     // WARNING: We can not put check here, because the inflation
     // will not update the displaced header. Once BasicLock is inflated,
@@ -75,6 +75,6 @@ void BasicLock::move_to(oop obj, BasicLock* dest) {
     // we can find any flavor mark in the displaced mark.
   }
 // [RGV] The next line appears to do nothing!
-  intptr_t dh = (intptr_t) displaced_header();
+  intptr_t dh = (intptr_t) displaced_header().value();
   dest->set_displaced_header(displaced_header());
 }

--- a/src/hotspot/share/runtime/basicLock.hpp
+++ b/src/hotspot/share/runtime/basicLock.hpp
@@ -26,6 +26,7 @@
 #define SHARE_VM_RUNTIME_BASICLOCK_HPP
 
 #include "oops/markOop.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/handles.hpp"
 
 class BasicLock {
@@ -34,8 +35,13 @@ class BasicLock {
  private:
   volatile markOop _displaced_header;
  public:
-  markOop      displaced_header() const               { return _displaced_header; }
-  void         set_displaced_header(markOop header)   { _displaced_header = header; }
+  markOop displaced_header() const {
+    return Atomic::load(&_displaced_header);
+  }
+
+  void set_displaced_header(markOop header) {
+    Atomic::store(header, &_displaced_header);
+  }
 
   void print_on(outputStream* st) const;
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1100,14 +1100,14 @@ void Deoptimization::relock_objects(GrowableArray<MonitorInfo*>* monitors, JavaT
       if (!mon_info->owner_is_scalar_replaced()) {
         Handle obj(thread, mon_info->owner());
         markOop mark = obj->mark();
-        if (UseBiasedLocking && mark->has_bias_pattern()) {
+        if (UseBiasedLocking && mark.has_bias_pattern()) {
           // New allocated objects may have the mark set to anonymously biased.
           // Also the deoptimized method may called methods with synchronization
           // where the thread-local object is bias locked to the current thread.
-          assert(mark->is_biased_anonymously() ||
-                 mark->biased_locker() == thread, "should be locked to current thread");
+          assert(mark.is_biased_anonymously() ||
+                 mark.biased_locker() == thread, "should be locked to current thread");
           // Reset mark word to unbiased prototype.
-          markOop unbiased_prototype = markOopDesc::prototype()->set_age(mark->age());
+          markOop unbiased_prototype = markOop::prototype().set_age(mark.age());
           obj->set_mark(unbiased_prototype);
         }
         BasicLock* lock = mon_info->lock();

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2586,7 +2586,7 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
   product(uintx, StringDeduplicationAgeThreshold, 3,                        \
           "A string must reach this age (or be promoted to an old region) " \
           "to be considered for deduplication")                             \
-          range(1, markOopDesc::max_age)                                    \
+          range(1, markOop::max_age)                                        \
                                                                             \
   diagnostic(bool, StringDeduplicationResizeALot, false,                    \
           "Force table resize every time the table is scanned")             \

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -302,7 +302,7 @@ void ObjectMonitor::enter(TRAPS) {
   if (Knob_SpinEarly && TrySpin (Self) > 0) {
     assert(_owner == Self, "invariant");
     assert(_recursions == 0, "invariant");
-    assert(((oop)(object()))->mark() == markOopDesc::encode(this), "invariant");
+    assert(((oop)(object()))->mark() == markOop::encode(this), "invariant");
     Self->_Stalled = 0;
     return;
   }
@@ -387,7 +387,7 @@ void ObjectMonitor::enter(TRAPS) {
   assert(_recursions == 0, "invariant");
   assert(_owner == Self, "invariant");
   assert(_succ != Self, "invariant");
-  assert(((oop)(object()))->mark() == markOopDesc::encode(this), "invariant");
+  assert(((oop)(object()))->mark() == markOop::encode(this), "invariant");
 
   // The thread -- now the owner -- is back in vm mode.
   // Report the glorious news via TI,DTrace and jvmstat.
@@ -621,7 +621,7 @@ void ObjectMonitor::EnterI(TRAPS) {
   assert(_owner == Self, "invariant");
   assert(object() != NULL, "invariant");
   // I'd like to write:
-  //   guarantee (((oop)(object()))->mark() == markOopDesc::encode(this), "invariant") ;
+  //   guarantee (((oop)(object()))->mark() == markOop::encode(this), "invariant") ;
   // but as we're at a safepoint that's not safe.
 
   UnlinkAfterAcquire(Self, &node);
@@ -694,7 +694,7 @@ void ObjectMonitor::ReenterI(Thread * Self, ObjectWaiter * SelfNode) {
   assert(SelfNode != NULL, "invariant");
   assert(SelfNode->_thread == Self, "invariant");
   assert(_waiters > 0, "invariant");
-  assert(((oop)(object()))->mark() == markOopDesc::encode(this), "invariant");
+  assert(((oop)(object()))->mark() == markOop::encode(this), "invariant");
   assert(((JavaThread *)Self)->thread_state() != _thread_blocked, "invariant");
   JavaThread * jt = (JavaThread *) Self;
 
@@ -769,7 +769,7 @@ void ObjectMonitor::ReenterI(Thread * Self, ObjectWaiter * SelfNode) {
   // In addition, Self.TState is stable.
 
   assert(_owner == Self, "invariant");
-  assert(((oop)(object()))->mark() == markOopDesc::encode(this), "invariant");
+  assert(((oop)(object()))->mark() == markOop::encode(this), "invariant");
   UnlinkAfterAcquire(Self, SelfNode);
   if (_succ == Self) _succ = NULL;
   assert(_succ != Self, "invariant");
@@ -1620,7 +1620,7 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
   // Verify a few postconditions
   assert(_owner == Self, "invariant");
   assert(_succ != Self, "invariant");
-  assert(((oop)(object()))->mark() == markOopDesc::encode(this), "invariant");
+  assert(((oop)(object()))->mark() == markOop::encode(this), "invariant");
 
   if (SyncFlags & 32) {
     OrderAccess::fence();

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -27,6 +27,7 @@
 
 #include "memory/allocation.hpp"
 #include "memory/padded.hpp"
+#include "oops/markOop.hpp"
 #include "runtime/os.hpp"
 #include "runtime/park.hpp"
 #include "runtime/perfData.hpp"
@@ -218,7 +219,7 @@ class ObjectMonitor {
   static int succ_offset_in_bytes()        { return offset_of(ObjectMonitor, _succ); }
   static int EntryList_offset_in_bytes()   { return offset_of(ObjectMonitor, _EntryList); }
 
-  // ObjectMonitor references can be ORed with markOopDesc::monitor_value
+  // ObjectMonitor references can be ORed with markOop::monitor_value
   // as part of the ObjectMonitor tagging mechanism. When we combine an
   // ObjectMonitor reference with an offset, we need to remove the tag
   // value in order to generate the proper address.
@@ -230,7 +231,7 @@ class ObjectMonitor {
   // to the ObjectMonitor reference manipulation code:
   //
   #define OM_OFFSET_NO_MONITOR_VALUE_TAG(f) \
-    ((ObjectMonitor::f ## _offset_in_bytes()) - markOopDesc::monitor_value)
+    ((ObjectMonitor::f ## _offset_in_bytes()) - markOop::monitor_value)
 
   markOop   header() const;
   volatile markOop* header_addr();

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3080,10 +3080,10 @@ JRT_LEAF(intptr_t*, SharedRuntime::OSR_migration_begin( JavaThread *thread) )
     if (kptr2->obj() != NULL) {         // Avoid 'holes' in the monitor array
       BasicLock *lock = kptr2->lock();
       // Inflate so the displaced header becomes position-independent
-      if (lock->displaced_header()->is_unlocked())
+      if (lock->displaced_header().is_unlocked())
         ObjectSynchronizer::inflate_helper(kptr2->obj());
       // Now the displaced header is free to move
-      buf[i++] = (intptr_t)lock->displaced_header();
+      buf[i++] = (intptr_t)lock->displaced_header().value();
       buf[i++] = cast_from_oop<intptr_t>(kptr2->obj());
     }
   }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -175,7 +175,7 @@ THREAD_LOCAL_DECL Thread* Thread::_thr_current = NULL;
 // Support for forcing alignment of thread objects for biased locking
 void* Thread::allocate(size_t size, bool throw_excpt, MEMFLAGS flags) {
   if (UseBiasedLocking) {
-    const int alignment = markOopDesc::biased_lock_alignment;
+    const int alignment = markOop::biased_lock_alignment;
     size_t aligned_size = size + (alignment - sizeof(intptr_t));
     void* real_malloc_addr = throw_excpt? AllocateHeap(aligned_size, flags, CURRENT_PC)
                                           : AllocateHeap(aligned_size, flags, CURRENT_PC,
@@ -302,9 +302,9 @@ Thread::Thread() {
 #endif // CHECK_UNHANDLED_OOPS
 #ifdef ASSERT
   if (UseBiasedLocking) {
-    assert((((uintptr_t) this) & (markOopDesc::biased_lock_alignment - 1)) == 0, "forced alignment of thread object failed");
+    assert((((uintptr_t) this) & (markOop::biased_lock_alignment - 1)) == 0, "forced alignment of thread object failed");
     assert(this == _real_malloc_address ||
-           this == align_up(_real_malloc_address, (int)markOopDesc::biased_lock_alignment),
+           this == align_up(_real_malloc_address, (int)markOop::biased_lock_alignment),
            "bug in forced alignment of thread objects");
   }
 #endif // ASSERT

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -222,7 +222,7 @@ void javaVFrame::print_lock_info_on(outputStream* st, int frame_count) {
       if (monitor->owner() != NULL) {
         // the monitor is associated with an object, i.e., it is locked
 
-        markOop mark = NULL;
+        markOop mark = markOop::zero();
         const char *lock_state = "locked"; // assume we have the monitor locked
         if (!found_first_monitor && frame_count == 0) {
           // If this is the first frame and we haven't found an owned
@@ -231,17 +231,17 @@ void javaVFrame::print_lock_info_on(outputStream* st, int frame_count) {
           // an inflated monitor that is first on the monitor list in
           // the first frame can block us on a monitor enter.
           mark = monitor->owner()->mark();
-          if (mark->has_monitor() &&
+          if (mark.has_monitor() &&
               ( // we have marked ourself as pending on this monitor
-                mark->monitor() == thread()->current_pending_monitor() ||
+                mark.monitor() == thread()->current_pending_monitor() ||
                 // we are not the owner of this monitor
-                !mark->monitor()->is_entered(thread())
+                !mark.monitor()->is_entered(thread())
               )) {
             lock_state = "waiting to lock";
           } else {
             // We own the monitor which is not as interesting so
             // disable the extra printing below.
-            mark = NULL;
+            mark = markOop::zero();
           }
         } else if (frame_count != 0) {
           // This is not the first frame so we either own this monitor
@@ -250,23 +250,23 @@ void javaVFrame::print_lock_info_on(outputStream* st, int frame_count) {
           // numbered frame on the stack, we have to check all the
           // monitors on the list for this frame.
           mark = monitor->owner()->mark();
-          if (mark->has_monitor() &&
+          if (mark.has_monitor() &&
               ( // we have marked ourself as pending on this monitor
-                mark->monitor() == thread()->current_pending_monitor() ||
+                mark.monitor() == thread()->current_pending_monitor() ||
                 // we are not the owner of this monitor
-                !mark->monitor()->is_entered(thread())
+                !mark.monitor()->is_entered(thread())
               )) {
             lock_state = "waiting to re-lock in wait()";
           } else {
             // We own the monitor which is not as interesting so
             // disable the extra printing below.
-            mark = NULL;
+            mark = markOop::zero();
           }
         }
         print_locked_object_class_name(st, Handle(THREAD, monitor->owner()), lock_state);
-        if (ObjectMonitor::Knob_Verbose && mark != NULL) {
+        if (ObjectMonitor::Knob_Verbose && mark.to_pointer() != NULL) {
           st->print("\t- lockbits=");
-          mark->print_on(st);
+          mark.print_on(st);
           st->cr();
         }
 

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1285,7 +1285,6 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
     declare_type(arrayOopDesc, oopDesc)                                   \
       declare_type(objArrayOopDesc, arrayOopDesc)                         \
     declare_type(instanceOopDesc, oopDesc)                                \
-    declare_type(markOopDesc, oopDesc)                                    \
                                                                           \
   /**************************************************/                    \
   /* MetadataOopDesc hierarchy (NOTE: some missing) */                    \
@@ -1325,7 +1324,6 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
   /* Oops */                                                              \
   /********/                                                              \
                                                                           \
-  declare_oop_type(markOop)                                               \
   declare_oop_type(objArrayOop)                                           \
   declare_oop_type(oop)                                                   \
   declare_oop_type(narrowOop)                                             \
@@ -1981,6 +1979,7 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
             declare_type(BitMapView, BitMap)                              \
                                                                           \
    declare_integer_type(AccessFlags)  /* FIXME: wrong type (not integer) */\
+   declare_integer_type(markOop)                                          \
   declare_toplevel_type(address)      /* FIXME: should this be an integer type? */\
    declare_integer_type(BasicType)   /* FIXME: wrong type (not integer) */\
   JVMTI_ONLY(declare_toplevel_type(BreakpointInfo))                       \
@@ -2642,45 +2641,45 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
   /* consistency. The mask constants are the only ones requiring */       \
   /* 64 bits (on 64-bit platforms). */                                    \
                                                                           \
-  declare_constant(markOopDesc::age_bits)                                 \
-  declare_constant(markOopDesc::lock_bits)                                \
-  declare_constant(markOopDesc::biased_lock_bits)                         \
-  declare_constant(markOopDesc::max_hash_bits)                            \
-  declare_constant(markOopDesc::hash_bits)                                \
+  declare_constant(markOop::age_bits)                                 \
+  declare_constant(markOop::lock_bits)                                \
+  declare_constant(markOop::biased_lock_bits)                         \
+  declare_constant(markOop::max_hash_bits)                            \
+  declare_constant(markOop::hash_bits)                                \
                                                                           \
-  declare_constant(markOopDesc::lock_shift)                               \
-  declare_constant(markOopDesc::biased_lock_shift)                        \
-  declare_constant(markOopDesc::age_shift)                                \
-  declare_constant(markOopDesc::hash_shift)                               \
+  declare_constant(markOop::lock_shift)                               \
+  declare_constant(markOop::biased_lock_shift)                        \
+  declare_constant(markOop::age_shift)                                \
+  declare_constant(markOop::hash_shift)                               \
                                                                           \
-  declare_constant(markOopDesc::lock_mask)                                \
-  declare_constant(markOopDesc::lock_mask_in_place)                       \
-  declare_constant(markOopDesc::biased_lock_mask)                         \
-  declare_constant(markOopDesc::biased_lock_mask_in_place)                \
-  declare_constant(markOopDesc::biased_lock_bit_in_place)                 \
-  declare_constant(markOopDesc::age_mask)                                 \
-  declare_constant(markOopDesc::age_mask_in_place)                        \
-  declare_constant(markOopDesc::epoch_mask)                               \
-  declare_constant(markOopDesc::epoch_mask_in_place)                      \
-  declare_constant(markOopDesc::hash_mask)                                \
-  declare_constant(markOopDesc::hash_mask_in_place)                       \
-  declare_constant(markOopDesc::biased_lock_alignment)                    \
+  declare_constant(markOop::lock_mask)                                \
+  declare_constant(markOop::lock_mask_in_place)                       \
+  declare_constant(markOop::biased_lock_mask)                         \
+  declare_constant(markOop::biased_lock_mask_in_place)                \
+  declare_constant(markOop::biased_lock_bit_in_place)                 \
+  declare_constant(markOop::age_mask)                                 \
+  declare_constant(markOop::age_mask_in_place)                        \
+  declare_constant(markOop::epoch_mask)                               \
+  declare_constant(markOop::epoch_mask_in_place)                      \
+  declare_constant(markOop::hash_mask)                                \
+  declare_constant(markOop::hash_mask_in_place)                       \
+  declare_constant(markOop::biased_lock_alignment)                    \
                                                                           \
-  declare_constant(markOopDesc::locked_value)                             \
-  declare_constant(markOopDesc::unlocked_value)                           \
-  declare_constant(markOopDesc::monitor_value)                            \
-  declare_constant(markOopDesc::marked_value)                             \
-  declare_constant(markOopDesc::biased_lock_pattern)                      \
+  declare_constant(markOop::locked_value)                             \
+  declare_constant(markOop::unlocked_value)                           \
+  declare_constant(markOop::monitor_value)                            \
+  declare_constant(markOop::marked_value)                             \
+  declare_constant(markOop::biased_lock_pattern)                      \
                                                                           \
-  declare_constant(markOopDesc::no_hash)                                  \
-  declare_constant(markOopDesc::no_hash_in_place)                         \
-  declare_constant(markOopDesc::no_lock_in_place)                         \
-  declare_constant(markOopDesc::max_age)                                  \
+  declare_constant(markOop::no_hash)                                  \
+  declare_constant(markOop::no_hash_in_place)                         \
+  declare_constant(markOop::no_lock_in_place)                         \
+  declare_constant(markOop::max_age)                                  \
                                                                           \
   /* Constants in markOop used by CMS. */                                 \
-  declare_constant(markOopDesc::cms_shift)                                \
-  declare_constant(markOopDesc::cms_mask)                                 \
-  declare_constant(markOopDesc::size_shift)                               \
+  declare_constant(markOop::cms_shift)                                \
+  declare_constant(markOop::cms_mask)                                 \
+  declare_constant(markOop::size_shift)                               \
                                                                           \
   /* InvocationCounter constants */                                       \
   declare_constant(InvocationCounter::count_increment)                    \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Mark.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Mark.java
@@ -51,39 +51,39 @@ public class Mark extends VMObject {
     Type type  = db.lookupType("oopDesc");
     markField  = type.getCIntegerField("_mark");
 
-    ageBits             = db.lookupLongConstant("markOopDesc::age_bits").longValue();
-    lockBits            = db.lookupLongConstant("markOopDesc::lock_bits").longValue();
-    biasedLockBits      = db.lookupLongConstant("markOopDesc::biased_lock_bits").longValue();
-    maxHashBits         = db.lookupLongConstant("markOopDesc::max_hash_bits").longValue();
-    hashBits            = db.lookupLongConstant("markOopDesc::hash_bits").longValue();
-    lockShift           = db.lookupLongConstant("markOopDesc::lock_shift").longValue();
-    biasedLockShift     = db.lookupLongConstant("markOopDesc::biased_lock_shift").longValue();
-    ageShift            = db.lookupLongConstant("markOopDesc::age_shift").longValue();
-    hashShift           = db.lookupLongConstant("markOopDesc::hash_shift").longValue();
-    lockMask            = db.lookupLongConstant("markOopDesc::lock_mask").longValue();
-    lockMaskInPlace     = db.lookupLongConstant("markOopDesc::lock_mask_in_place").longValue();
-    biasedLockMask      = db.lookupLongConstant("markOopDesc::biased_lock_mask").longValue();
-    biasedLockMaskInPlace  = db.lookupLongConstant("markOopDesc::biased_lock_mask_in_place").longValue();
-    biasedLockBitInPlace  = db.lookupLongConstant("markOopDesc::biased_lock_bit_in_place").longValue();
-    ageMask             = db.lookupLongConstant("markOopDesc::age_mask").longValue();
-    ageMaskInPlace      = db.lookupLongConstant("markOopDesc::age_mask_in_place").longValue();
-    hashMask            = db.lookupLongConstant("markOopDesc::hash_mask").longValue();
-    hashMaskInPlace     = db.lookupLongConstant("markOopDesc::hash_mask_in_place").longValue();
-    biasedLockAlignment  = db.lookupLongConstant("markOopDesc::biased_lock_alignment").longValue();
-    lockedValue         = db.lookupLongConstant("markOopDesc::locked_value").longValue();
-    unlockedValue       = db.lookupLongConstant("markOopDesc::unlocked_value").longValue();
-    monitorValue        = db.lookupLongConstant("markOopDesc::monitor_value").longValue();
-    markedValue         = db.lookupLongConstant("markOopDesc::marked_value").longValue();
-    biasedLockPattern = db.lookupLongConstant("markOopDesc::biased_lock_pattern").longValue();
-    noHash              = db.lookupLongConstant("markOopDesc::no_hash").longValue();
-    noHashInPlace       = db.lookupLongConstant("markOopDesc::no_hash_in_place").longValue();
-    noLockInPlace       = db.lookupLongConstant("markOopDesc::no_lock_in_place").longValue();
-    maxAge              = db.lookupLongConstant("markOopDesc::max_age").longValue();
+    ageBits             = db.lookupLongConstant("markOop::age_bits").longValue();
+    lockBits            = db.lookupLongConstant("markOop::lock_bits").longValue();
+    biasedLockBits      = db.lookupLongConstant("markOop::biased_lock_bits").longValue();
+    maxHashBits         = db.lookupLongConstant("markOop::max_hash_bits").longValue();
+    hashBits            = db.lookupLongConstant("markOop::hash_bits").longValue();
+    lockShift           = db.lookupLongConstant("markOop::lock_shift").longValue();
+    biasedLockShift     = db.lookupLongConstant("markOop::biased_lock_shift").longValue();
+    ageShift            = db.lookupLongConstant("markOop::age_shift").longValue();
+    hashShift           = db.lookupLongConstant("markOop::hash_shift").longValue();
+    lockMask            = db.lookupLongConstant("markOop::lock_mask").longValue();
+    lockMaskInPlace     = db.lookupLongConstant("markOop::lock_mask_in_place").longValue();
+    biasedLockMask      = db.lookupLongConstant("markOop::biased_lock_mask").longValue();
+    biasedLockMaskInPlace  = db.lookupLongConstant("markOop::biased_lock_mask_in_place").longValue();
+    biasedLockBitInPlace  = db.lookupLongConstant("markOop::biased_lock_bit_in_place").longValue();
+    ageMask             = db.lookupLongConstant("markOop::age_mask").longValue();
+    ageMaskInPlace      = db.lookupLongConstant("markOop::age_mask_in_place").longValue();
+    hashMask            = db.lookupLongConstant("markOop::hash_mask").longValue();
+    hashMaskInPlace     = db.lookupLongConstant("markOop::hash_mask_in_place").longValue();
+    biasedLockAlignment  = db.lookupLongConstant("markOop::biased_lock_alignment").longValue();
+    lockedValue         = db.lookupLongConstant("markOop::locked_value").longValue();
+    unlockedValue       = db.lookupLongConstant("markOop::unlocked_value").longValue();
+    monitorValue        = db.lookupLongConstant("markOop::monitor_value").longValue();
+    markedValue         = db.lookupLongConstant("markOop::marked_value").longValue();
+    biasedLockPattern = db.lookupLongConstant("markOop::biased_lock_pattern").longValue();
+    noHash              = db.lookupLongConstant("markOop::no_hash").longValue();
+    noHashInPlace       = db.lookupLongConstant("markOop::no_hash_in_place").longValue();
+    noLockInPlace       = db.lookupLongConstant("markOop::no_lock_in_place").longValue();
+    maxAge              = db.lookupLongConstant("markOop::max_age").longValue();
 
     /* Constants in markOop used by CMS. */
-    cmsShift            = db.lookupLongConstant("markOopDesc::cms_shift").longValue();
-    cmsMask             = db.lookupLongConstant("markOopDesc::cms_mask").longValue();
-    sizeShift           = db.lookupLongConstant("markOopDesc::size_shift").longValue();
+    cmsShift            = db.lookupLongConstant("markOop::cms_shift").longValue();
+    cmsMask             = db.lookupLongConstant("markOop::cms_mask").longValue();
+    sizeShift           = db.lookupLongConstant("markOop::size_shift").longValue();
   }
 
   // Field accessors

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
@@ -134,11 +134,11 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
     // This is only valid on AMD64.
     final int runtimeCallStackSize = getConstant("frame::arg_reg_save_area_bytes", Integer.class, osArch.equals("amd64") ? null : 0);
 
-    private final int markWordNoHashInPlace = getConstant("markOopDesc::no_hash_in_place", Integer.class);
-    private final int markWordNoLockInPlace = getConstant("markOopDesc::no_lock_in_place", Integer.class);
+    private final int markWordNoHashInPlace = getConstant("markOop::no_hash_in_place", Integer.class);
+    private final int markWordNoLockInPlace = getConstant("markOop::no_lock_in_place", Integer.class);
 
     /**
-     * See {@code markOopDesc::prototype()}.
+     * See {@code markOop::prototype()}.
      */
     long arrayPrototypeMarkWord() {
         return markWordNoHashInPlace | markWordNoLockInPlace;

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -399,17 +399,17 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigBase {
 
     public final int osThreadInterruptedOffset = getFieldOffset("OSThread::_interrupted", Integer.class, "jint");
 
-    public final long markOopDescHashShift = getConstant("markOopDesc::hash_shift", Long.class);
+    public final long markOopHashShift = getConstant("markOop::hash_shift", Long.class);
 
-    public final int biasedLockMaskInPlace = getConstant("markOopDesc::biased_lock_mask_in_place", Integer.class);
-    public final int ageMaskInPlace = getConstant("markOopDesc::age_mask_in_place", Integer.class);
-    public final int epochMaskInPlace = getConstant("markOopDesc::epoch_mask_in_place", Integer.class);
-    public final long markOopDescHashMask = getConstant("markOopDesc::hash_mask", Long.class);
-    public final long markOopDescHashMaskInPlace = getConstant("markOopDesc::hash_mask_in_place", Long.class);
+    public final int biasedLockMaskInPlace = getConstant("markOop::biased_lock_mask_in_place", Integer.class);
+    public final int ageMaskInPlace = getConstant("markOop::age_mask_in_place", Integer.class);
+    public final int epochMaskInPlace = getConstant("markOop::epoch_mask_in_place", Integer.class);
+    public final long markOopHashMask = getConstant("markOop::hash_mask", Long.class);
+    public final long markOopHashMaskInPlace = getConstant("markOop::hash_mask_in_place", Long.class);
 
-    public final int unlockedMask = getConstant("markOopDesc::unlocked_value", Integer.class);
-    public final int monitorMask = getConstant("markOopDesc::monitor_value", Integer.class, -1);
-    public final int biasedLockPattern = getConstant("markOopDesc::biased_lock_pattern", Integer.class);
+    public final int unlockedMask = getConstant("markOop::unlocked_value", Integer.class);
+    public final int monitorMask = getConstant("markOop::monitor_value", Integer.class, -1);
+    public final int biasedLockPattern = getConstant("markOop::biased_lock_pattern", Integer.class);
 
     // This field has no type in vmStructs.cpp
     public final int objectMonitorOwner = getFieldOffset("ObjectMonitor::_owner", Integer.class, null, -1);
@@ -417,34 +417,34 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigBase {
     public final int objectMonitorCxq = getFieldOffset("ObjectMonitor::_cxq", Integer.class, "ObjectWaiter*", -1);
     public final int objectMonitorEntryList = getFieldOffset("ObjectMonitor::_EntryList", Integer.class, "ObjectWaiter*", -1);
 
-    public final int markWordNoHashInPlace = getConstant("markOopDesc::no_hash_in_place", Integer.class);
-    public final int markWordNoLockInPlace = getConstant("markOopDesc::no_lock_in_place", Integer.class);
+    public final int markWordNoHashInPlace = getConstant("markOop::no_hash_in_place", Integer.class);
+    public final int markWordNoLockInPlace = getConstant("markOop::no_lock_in_place", Integer.class);
 
     /**
-     * See {@code markOopDesc::prototype()}.
+     * See {@code markOop::prototype()}.
      */
     public long arrayPrototypeMarkWord() {
         return markWordNoHashInPlace | markWordNoLockInPlace;
     }
 
     /**
-     * See {@code markOopDesc::copy_set_hash()}.
+     * See {@code markOop::copy_set_hash()}.
      */
     public long tlabIntArrayMarkWord() {
-        long tmp = arrayPrototypeMarkWord() & (~markOopDescHashMaskInPlace);
-        tmp |= ((0x2 & markOopDescHashMask) << markOopDescHashShift);
+        long tmp = arrayPrototypeMarkWord() & (~markOopHashMaskInPlace);
+        tmp |= ((0x2 & markOopHashMask) << markOopHashShift);
         return tmp;
     }
 
     /**
      * Mark word right shift to get identity hash code.
      */
-    public final int identityHashCodeShift = getConstant("markOopDesc::hash_shift", Integer.class);
+    public final int identityHashCodeShift = getConstant("markOop::hash_shift", Integer.class);
 
     /**
      * Identity hash code value when uninitialized.
      */
-    public final int uninitializedIdentityHashCodeValue = getConstant("markOopDesc::no_hash", Integer.class);
+    public final int uninitializedIdentityHashCodeValue = getConstant("markOop::no_hash", Integer.class);
 
     public final int methodAccessFlagsOffset = getFieldOffset("Method::_access_flags", Integer.class, "AccessFlags");
     public final int methodConstMethodOffset = getFieldOffset("Method::_constMethod", Integer.class, "ConstMethod*");

--- a/test/hotspot/gtest/gc/shared/test_preservedMarks.cpp
+++ b/test/hotspot/gtest/gc/shared/test_preservedMarks.cpp
@@ -45,11 +45,11 @@ public:
   markOop mark() { return _oop.mark_raw(); }
   void set_mark(markOop m) { _oop.set_mark_raw(m); }
   void forward_to(oop obj) {
-    markOop m = markOopDesc::encode_pointer_as_mark(obj);
+    markOop m = markOop::encode_pointer_as_mark(obj);
     _oop.set_mark_raw(m);
   }
 
-  static markOop originalMark() { return markOop(markOopDesc::lock_mask_in_place); }
+  static markOop originalMark() { return markOop(markOop::lock_mask_in_place); }
   static markOop changedMark()  { return markOop(0x4711); }
 };
 

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbAttach.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbAttach.java
@@ -55,7 +55,7 @@ public class ClhsdbAttach {
                     "detach",
                     "universe",
                     "reattach",
-                    "longConstant markOopDesc::locked_value");
+                    "longConstant markOop::locked_value");
 
             Map<String, List<String>> expStrMap = new HashMap<>();
             expStrMap.put("where", List.of(
@@ -64,8 +64,8 @@ public class ClhsdbAttach {
                     "MaxJavaStackTraceDepth = "));
             expStrMap.put("universe", List.of(
                     "Command not valid until attached to a VM"));
-            expStrMap.put("longConstant markOopDesc::locked_value", List.of(
-                    "longConstant markOopDesc::locked_value"));
+            expStrMap.put("longConstant markOop::locked_value", List.of(
+                    "longConstant markOop::locked_value"));
 
             test.run(-1, cmds, expStrMap, null);
         } catch (Exception ex) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLongConstant.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLongConstant.java
@@ -51,21 +51,21 @@ public class ClhsdbLongConstant {
 
             List<String> cmds = List.of(
                     "longConstant",
-                    "longConstant markOopDesc::locked_value",
-                    "longConstant markOopDesc::lock_bits",
+                    "longConstant markOop::locked_value",
+                    "longConstant markOop::lock_bits",
                     "longConstant jtreg::test 6",
                     "longConstant jtreg::test");
 
             Map<String, List<String>> expStrMap = new HashMap<>();
             expStrMap.put("longConstant", List.of(
-                    "longConstant markOopDesc::locked_value",
-                    "longConstant markOopDesc::lock_bits",
+                    "longConstant markOop::locked_value",
+                    "longConstant markOop::lock_bits",
                     "InvocationCounter::count_increment",
-                    "markOopDesc::epoch_mask_in_place"));
-            expStrMap.put("longConstant markOopDesc::locked_value", List.of(
-                    "longConstant markOopDesc::locked_value"));
-            expStrMap.put("longConstant markOopDesc::lock_bits", List.of(
-                    "longConstant markOopDesc::lock_bits"));
+                    "markOop::epoch_mask_in_place"));
+            expStrMap.put("longConstant markOop::locked_value", List.of(
+                    "longConstant markOop::locked_value"));
+            expStrMap.put("longConstant markOop::lock_bits", List.of(
+                    "longConstant markOop::lock_bits"));
             expStrMap.put("longConstant jtreg::test", List.of(
                     "longConstant jtreg::test 6"));
 
@@ -96,12 +96,12 @@ public class ClhsdbLongConstant {
         // Expected output snippet is of the form (on x64-64):
         // ...
         // longConstant VM_Version::CPU_SHA 17179869184
-        // longConstant markOopDesc::biased_lock_bits 1
-        // longConstant markOopDesc::age_shift 3
-        // longConstant markOopDesc::hash_mask_in_place 549755813632
+        // longConstant markOop::biased_lock_bits 1
+        // longConstant markOop::age_shift 3
+        // longConstant markOop::hash_mask_in_place 549755813632
         // ...
 
-        checkLongValue("markOopDesc::hash_mask_in_place",
+        checkLongValue("markOop::hash_mask_in_place",
                        longConstantOutput,
                        Platform.is64bit() ? 549755813632L: 4294967168L);
 


### PR DESCRIPTION
This patch backports changes from JDK14 commit ae5615c6142a4dc0d9033462f4880d7b3c127e26. It does not rename the class to markWord as the original patch does, but instead converts markOop to a markWord equivalent in-place. This patch allows the JDK to be built with Clang 13, as it avoids undefined behavior. 

See the following for more information:
- https://bugs.openjdk.java.net/browse/JDK-8229258
- https://bugs.gentoo.org/817995
- https://mail.openjdk.java.net/pipermail/hotspot-dev/2019-July/038704.html
- https://mail.openjdk.java.net/pipermail/hotspot-dev/2019-July/038712.html
- https://reviews.llvm.org/D99790#2678384

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8229258](https://bugs.openjdk.java.net/browse/JDK-8229258)

### Issue
 * [JDK-8229258](https://bugs.openjdk.java.net/browse/JDK-8229258): Rework markOop and markOopDesc into a simpler mark word value carrier ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.java.net/jdk11u pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u/pull/23.diff">https://git.openjdk.java.net/jdk11u/pull/23.diff</a>

</details>
