### PR TITLE
8210205: build fails on AIX in hotspot cpp tests (for example getstacktr001.cpp)

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr001/getstacktr001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr001/getstacktr001.cpp
@@ -53,7 +53,7 @@ static frame_info frames[] = {
      "([Ljava/lang/String;)V"}
 };
 
-#define NUMBER_OF_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
+#define NUMBER_OF_STACK_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
 
 #ifdef STATIC_BUILD
 JNIEXPORT jint JNICALL Agent_OnLoad_getstacktr001(JavaVM *jvm, char *options, void *reserved) {
@@ -95,7 +95,7 @@ Java_nsk_jvmti_GetStackTrace_getstacktr001_chain(JNIEnv *env, jclass cls) {
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_GetStackTrace_getstacktr001_check(JNIEnv *env, jclass cls, jthread thread) {
     jvmtiError err;
-    jvmtiFrameInfo f[NUMBER_OF_FRAMES + 1];
+    jvmtiFrameInfo f[NUMBER_OF_STACK_FRAMES + 1];
     jclass callerClass;
     char *sigClass, *name, *sig, *generic;
     jint i, count;
@@ -107,16 +107,16 @@ Java_nsk_jvmti_GetStackTrace_getstacktr001_check(JNIEnv *env, jclass cls, jthrea
     }
 
     err = jvmti->GetStackTrace(thread, 0,
-        NUMBER_OF_FRAMES + 1, f, &count);
+        NUMBER_OF_STACK_FRAMES + 1, f, &count);
     if (err != JVMTI_ERROR_NONE) {
         printf("(GetStackTrace) unexpected error: %s (%d)\n",
                TranslateError(err), err);
         result = STATUS_FAILED;
         return;
     }
-    if (count != NUMBER_OF_FRAMES) {
+    if (count != NUMBER_OF_STACK_FRAMES) {
         printf("Wrong number of frames: %d, expected: %d\n",
-               count, NUMBER_OF_FRAMES);
+               count, NUMBER_OF_STACK_FRAMES);
         result = STATUS_FAILED;
     }
     for (i = 0; i < count; i++) {
@@ -151,7 +151,7 @@ Java_nsk_jvmti_GetStackTrace_getstacktr001_check(JNIEnv *env, jclass cls, jthrea
             printf(">>>   method: \"%s%s\"\n", name, sig);
             printf(">>>   %d ... done\n", i);
         }
-        if (i < NUMBER_OF_FRAMES) {
+        if (i < NUMBER_OF_STACK_FRAMES) {
             if (sigClass == NULL || strcmp(sigClass, frames[i].cls) != 0) {
                 printf("(frame#%d) wrong class sig: \"%s\", expected: \"%s\"\n",
                        i, sigClass, frames[i].cls);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr003/getstacktr003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr003/getstacktr003.cpp
@@ -50,8 +50,8 @@ static frame_info frames[] = {
     {"Lnsk/jvmti/GetStackTrace/getstacktr003$TestThread;", "run", "()V"},
 };
 
-#define NUMBER_OF_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
-#define MAX_NUMBER_OF_FRAMES 32
+#define NUMBER_OF_STACK_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
+#define MAX_NUMBER_OF_STACK_FRAMES 32
 
 #ifdef STATIC_BUILD
 JNIEXPORT jint JNICALL Agent_OnLoad_getstacktr003(JavaVM *jvm, char *options, void *reserved) {
@@ -123,7 +123,7 @@ Java_nsk_jvmti_GetStackTrace_getstacktr003_chain(JNIEnv *env, jclass cls) {
 JNIEXPORT int JNICALL
 Java_nsk_jvmti_GetStackTrace_getstacktr003_check(JNIEnv *env, jclass cls, jthread thread) {
     jvmtiError err;
-    jvmtiFrameInfo f[MAX_NUMBER_OF_FRAMES];
+    jvmtiFrameInfo f[MAX_NUMBER_OF_STACK_FRAMES];
     jclass callerClass;
     char *sigClass, *name, *sig, *generic;
     jint i, count;
@@ -146,16 +146,16 @@ Java_nsk_jvmti_GetStackTrace_getstacktr003_check(JNIEnv *env, jclass cls, jthrea
     }
 
     err = jvmti->GetStackTrace(thread,
-        0, MAX_NUMBER_OF_FRAMES, f, &count);
+        0, MAX_NUMBER_OF_STACK_FRAMES, f, &count);
     if (err != JVMTI_ERROR_NONE) {
         printf("(GetStackTrace) unexpected error: %s (%d)\n",
                TranslateError(err), err);
         result = STATUS_FAILED;
         return result;
     }
-    if (count < NUMBER_OF_FRAMES) {
+    if (count < NUMBER_OF_STACK_FRAMES) {
         printf("Number of frames: %d is less then expected: %d\n",
-               count, NUMBER_OF_FRAMES);
+               count, NUMBER_OF_STACK_FRAMES);
         result = STATUS_FAILED;
     }
     for (i = 0; i < count; i++) {
@@ -191,20 +191,20 @@ Java_nsk_jvmti_GetStackTrace_getstacktr003_check(JNIEnv *env, jclass cls, jthrea
             printf(">>>   method: \"%s%s\"\n", name, sig);
             printf(">>>   %d ... done\n", i);
         }
-        if (i < NUMBER_OF_FRAMES) {
-            if (sigClass == NULL || strcmp(sigClass, frames[NUMBER_OF_FRAMES-1-i].cls) != 0) {
+        if (i < NUMBER_OF_STACK_FRAMES) {
+            if (sigClass == NULL || strcmp(sigClass, frames[NUMBER_OF_STACK_FRAMES-1-i].cls) != 0) {
                 printf("(frame#%d) wrong class sig: \"%s\", expected: \"%s\"\n",
-                       NUMBER_OF_FRAMES-1-i, sigClass, frames[NUMBER_OF_FRAMES-1-i].cls);
+                       NUMBER_OF_STACK_FRAMES-1-i, sigClass, frames[NUMBER_OF_STACK_FRAMES-1-i].cls);
                 result = STATUS_FAILED;
             }
-            if (name == NULL || strcmp(name, frames[NUMBER_OF_FRAMES-1-i].name) != 0) {
+            if (name == NULL || strcmp(name, frames[NUMBER_OF_STACK_FRAMES-1-i].name) != 0) {
                 printf("(frame#%d) wrong method name: \"%s\", expected: \"%s\"\n",
-                       NUMBER_OF_FRAMES-1-i, name, frames[NUMBER_OF_FRAMES-1-i].name);
+                       NUMBER_OF_STACK_FRAMES-1-i, name, frames[NUMBER_OF_STACK_FRAMES-1-i].name);
                 result = STATUS_FAILED;
             }
-            if (sig == NULL || strcmp(sig, frames[NUMBER_OF_FRAMES-1-i].sig) != 0) {
+            if (sig == NULL || strcmp(sig, frames[NUMBER_OF_STACK_FRAMES-1-i].sig) != 0) {
                 printf("(frame#%d) wrong method sig: \"%s\", expected: \"%s\"\n",
-                       NUMBER_OF_FRAMES-1-i, sig, frames[NUMBER_OF_FRAMES-1-i].sig);
+                       NUMBER_OF_STACK_FRAMES-1-i, sig, frames[NUMBER_OF_STACK_FRAMES-1-i].sig);
                 result = STATUS_FAILED;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr004/getstacktr004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr004/getstacktr004.cpp
@@ -54,26 +54,26 @@ static frame_info frames[] = {
     {"Lnsk/jvmti/GetStackTrace/getstacktr004$TestThread;", "run", "()V"},
 };
 
-#define NUMBER_OF_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
+#define NUMBER_OF_STACK_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
 
 void check(jvmtiEnv *jvmti_env, jthread thr) {
     jvmtiError err;
-    jvmtiFrameInfo f[NUMBER_OF_FRAMES + 1];
+    jvmtiFrameInfo f[NUMBER_OF_STACK_FRAMES + 1];
     jclass callerClass;
     char *sigClass, *name, *sig, *generic;
     jint i, count;
 
     err = jvmti_env->GetStackTrace(thr,
-        0, NUMBER_OF_FRAMES + 1, f, &count);
+        0, NUMBER_OF_STACK_FRAMES + 1, f, &count);
     if (err != JVMTI_ERROR_NONE) {
         printf("(GetStackTrace) unexpected error: %s (%d)\n",
                TranslateError(err), err);
         result = STATUS_FAILED;
         return;
     }
-    if (count != NUMBER_OF_FRAMES) {
+    if (count != NUMBER_OF_STACK_FRAMES) {
         printf("Wrong frame count, expected: %d, actual: %d\n",
-               NUMBER_OF_FRAMES, count);
+               NUMBER_OF_STACK_FRAMES, count);
         result = STATUS_FAILED;
     }
 
@@ -112,7 +112,7 @@ void check(jvmtiEnv *jvmti_env, jthread thr) {
             printf(">>>   class:  \"%s\"\n", sigClass);
             printf(">>>   method: \"%s%s\"\n", name, sig);
         }
-        if (i < NUMBER_OF_FRAMES) {
+        if (i < NUMBER_OF_STACK_FRAMES) {
             if (sigClass == NULL || strcmp(sigClass, frames[i].cls) != 0) {
                 printf("(frame#%d) wrong class sig: \"%s\", expected: \"%s\"\n",
                        i, sigClass, frames[i].cls);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr005/getstacktr005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr005/getstacktr005.cpp
@@ -53,26 +53,26 @@ static frame_info frames[] = {
     {"Lnsk/jvmti/GetStackTrace/getstacktr005$TestThread;", "run", "()V"},
 };
 
-#define NUMBER_OF_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
+#define NUMBER_OF_STACK_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
 
 void check(jvmtiEnv *jvmti_env, jthread thr) {
     jvmtiError err;
-    jvmtiFrameInfo f[NUMBER_OF_FRAMES + 1];
+    jvmtiFrameInfo f[NUMBER_OF_STACK_FRAMES + 1];
     jclass callerClass;
     char *sigClass, *name, *sig, *generic;
     jint i, count;
 
     err = jvmti_env->GetStackTrace(thr,
-        0, NUMBER_OF_FRAMES + 1, f, &count);
+        0, NUMBER_OF_STACK_FRAMES + 1, f, &count);
     if (err != JVMTI_ERROR_NONE) {
         printf("(GetStackTrace) unexpected error: %s (%d)\n",
                TranslateError(err), err);
         result = STATUS_FAILED;
         return;
     }
-    if (count != NUMBER_OF_FRAMES) {
+    if (count != NUMBER_OF_STACK_FRAMES) {
         printf("Wrong frame count, expected: %d, actual: %d\n",
-               NUMBER_OF_FRAMES, count);
+               NUMBER_OF_STACK_FRAMES, count);
         result = STATUS_FAILED;
     }
 
@@ -111,7 +111,7 @@ void check(jvmtiEnv *jvmti_env, jthread thr) {
             printf(">>>   class:  \"%s\"\n", sigClass);
             printf(">>>   method: \"%s%s\"\n", name, sig);
         }
-        if (i < NUMBER_OF_FRAMES) {
+        if (i < NUMBER_OF_STACK_FRAMES) {
             if (sigClass == NULL || strcmp(sigClass, frames[i].cls) != 0) {
                 printf("(frame#%d) wrong class sig: \"%s\", expected: \"%s\"\n",
                        i, sigClass, frames[i].cls);
@@ -154,9 +154,9 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
         return;
     }
 
-    if (frameCount != NUMBER_OF_FRAMES + 1) {
+    if (frameCount != NUMBER_OF_STACK_FRAMES + 1) {
         printf("(bp) wrong frame count, expected: %d, actual: %d\n",
-               NUMBER_OF_FRAMES + 1, frameCount);
+               NUMBER_OF_STACK_FRAMES + 1, frameCount);
         result = STATUS_FAILED;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr006/getstacktr006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr006/getstacktr006.cpp
@@ -53,26 +53,26 @@ static frame_info frames[] = {
     {"Lnsk/jvmti/GetStackTrace/getstacktr006$TestThread;", "run", "()V"},
 };
 
-#define NUMBER_OF_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
+#define NUMBER_OF_STACK_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
 
 void check(jvmtiEnv *jvmti_env, jthread thr) {
     jvmtiError err;
-    jvmtiFrameInfo f[NUMBER_OF_FRAMES + 1];
+    jvmtiFrameInfo f[NUMBER_OF_STACK_FRAMES + 1];
     jclass callerClass;
     char *sigClass, *name, *sig, *generic;
     jint i, count;
 
     err = jvmti_env->GetStackTrace(thr,
-        0, NUMBER_OF_FRAMES + 1, f, &count);
+        0, NUMBER_OF_STACK_FRAMES + 1, f, &count);
     if (err != JVMTI_ERROR_NONE) {
         printf("(GetStackTrace) unexpected error: %s (%d)\n",
                TranslateError(err), err);
         result = STATUS_FAILED;
         return;
     }
-    if (count != NUMBER_OF_FRAMES) {
+    if (count != NUMBER_OF_STACK_FRAMES) {
         printf("Wrong frame count, expected: %d, actual: %d\n",
-               NUMBER_OF_FRAMES, count);
+               NUMBER_OF_STACK_FRAMES, count);
         result = STATUS_FAILED;
     }
 
@@ -111,7 +111,7 @@ void check(jvmtiEnv *jvmti_env, jthread thr) {
             printf(">>>   class:  \"%s\"\n", sigClass);
             printf(">>>   method: \"%s%s\"\n", name, sig);
         }
-        if (i < NUMBER_OF_FRAMES) {
+        if (i < NUMBER_OF_STACK_FRAMES) {
             if (sigClass == NULL || strcmp(sigClass, frames[i].cls) != 0) {
                 printf("(frame#%d) wrong class sig: \"%s\", expected: \"%s\"\n",
                        i, sigClass, frames[i].cls);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr007/getstacktr007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr007/getstacktr007.cpp
@@ -55,26 +55,26 @@ static frame_info frames[] = {
     {"Lnsk/jvmti/GetStackTrace/getstacktr007$TestThread;", "run", "()V"},
 };
 
-#define NUMBER_OF_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
+#define NUMBER_OF_STACK_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
 
 void check(jvmtiEnv *jvmti_env, jthread thr) {
     jvmtiError err;
-    jvmtiFrameInfo f[NUMBER_OF_FRAMES + 1];
+    jvmtiFrameInfo f[NUMBER_OF_STACK_FRAMES + 1];
     jclass callerClass;
     char *sigClass, *name, *sig, *generic;
     jint i, count;
 
     err = jvmti_env->GetStackTrace(thr,
-        0, NUMBER_OF_FRAMES + 1, f, &count);
+        0, NUMBER_OF_STACK_FRAMES + 1, f, &count);
     if (err != JVMTI_ERROR_NONE) {
         printf("(GetStackTrace) unexpected error: %s (%d)\n",
                TranslateError(err), err);
         result = STATUS_FAILED;
         return;
     }
-    if (count != NUMBER_OF_FRAMES) {
+    if (count != NUMBER_OF_STACK_FRAMES) {
         printf("Wrong frame count, expected: %d, actual: %d\n",
-               NUMBER_OF_FRAMES, count);
+               NUMBER_OF_STACK_FRAMES, count);
         result = STATUS_FAILED;
     }
 
@@ -113,7 +113,7 @@ void check(jvmtiEnv *jvmti_env, jthread thr) {
             printf(">>>   class:  \"%s\"\n", sigClass);
             printf(">>>   method: \"%s%s\"\n", name, sig);
         }
-        if (i < NUMBER_OF_FRAMES) {
+        if (i < NUMBER_OF_STACK_FRAMES) {
             if (sigClass == NULL || strcmp(sigClass, frames[i].cls) != 0) {
                 printf("(frame#%d) wrong class sig: \"%s\", expected: \"%s\"\n",
                        i, sigClass, frames[i].cls);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr008/getstacktr008.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace/getstacktr008/getstacktr008.cpp
@@ -59,11 +59,11 @@ static frame_info frames[] = {
     {"Lnsk/jvmti/GetStackTrace/getstacktr008$TestThread;", "run", "()V"},
 };
 
-#define NUMBER_OF_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
+#define NUMBER_OF_STACK_FRAMES ((int) (sizeof(frames)/sizeof(frame_info)))
 
 void check(jvmtiEnv *jvmti_env, jthread thr, int offset, const char *note) {
     jvmtiError err;
-    jvmtiFrameInfo f[NUMBER_OF_FRAMES + 1];
+    jvmtiFrameInfo f[NUMBER_OF_STACK_FRAMES + 1];
     jclass callerClass;
     char *sigClass, *name, *sig, *generic;
     jint i, count;
@@ -73,7 +73,7 @@ void check(jvmtiEnv *jvmti_env, jthread thr, int offset, const char *note) {
     }
 
     err = jvmti_env->GetStackTrace(thr,
-        0, NUMBER_OF_FRAMES + 1, f, &count);
+        0, NUMBER_OF_STACK_FRAMES + 1, f, &count);
     if (err != JVMTI_ERROR_NONE) {
         printf("(%s, GetStackTrace) unexpected error: %s (%d)\n",
                note, TranslateError(err), err);
@@ -85,9 +85,9 @@ void check(jvmtiEnv *jvmti_env, jthread thr, int offset, const char *note) {
             printf(">>>   frame count: %d\n", count);
     }
 
-    if (count != (jint)(NUMBER_OF_FRAMES - offset)) {
+    if (count != (jint)(NUMBER_OF_STACK_FRAMES - offset)) {
         printf("(%s) wrong frame count, expected: %d, actual: %d\n",
-               note, NUMBER_OF_FRAMES, count);
+               note, NUMBER_OF_STACK_FRAMES, count);
         result = STATUS_FAILED;
     }
     for (i = 0; i < count; i++) {
@@ -122,7 +122,7 @@ void check(jvmtiEnv *jvmti_env, jthread thr, int offset, const char *note) {
             printf(">>>   class:  \"%s\"\n", sigClass);
             printf(">>>   method: \"%s%s\"\n", name, sig);
         }
-        if (i < NUMBER_OF_FRAMES) {
+        if (i < NUMBER_OF_STACK_FRAMES) {
             if (sigClass == NULL ||
                     strcmp(sigClass, frames[i + offset].cls) != 0) {
                 printf("(%s, frame#%d) wrong class sig: \"%s\",\n",


### PR DESCRIPTION
I am creating this PR in response to a build issue brought to my attention by a member of the Adoptium Group. The issue is blocking their build as noted [here](https://github.com/adoptium/temurin-build/issues/2807).

This PR renames instances of `NUMBER_OF_FRAMES` and `MAXIMUM_NUMBER_OF_FRAMES` to `NUMBER_OF_STACK_FRAMES` and `MAXIMUM_NUMBER_OF_STACK_FRAMES` respectively in several files in the directory `jdk11u/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetStackTrace`. This change fixes the name collision preventing build.

This fix has been tested on my AIX development machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8210205](https://bugs.openjdk.java.net/browse/JDK-8210205): build fails on AIX in hotspot cpp tests (for example getstacktr001.cpp)


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)
 * [Andrew Leonard](https://openjdk.java.net/census#aleonard) (@andrew-m-leonard - no project role)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.java.net/jdk11u pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u/pull/24.diff">https://git.openjdk.java.net/jdk11u/pull/24.diff</a>

</details>
