### PR TITLE
8218546: Unable to connect to https://google.com using java.net.HttpClient

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -614,10 +614,6 @@ class Stream<T> extends ExchangeImpl<T> {
         if (contentLength > 0) {
             h.setHeader("content-length", Long.toString(contentLength));
         }
-        URI uri = request.uri();
-        if (uri != null) {
-            h.setHeader("host", Utils.hostString(request));
-        }
         HttpHeaders sysh = filterHeaders(h.build());
         HttpHeaders userh = filterHeaders(request.getUserHeaders());
         // Filter context restricted from userHeaders


### PR DESCRIPTION
See http://mail.openjdk.java.net/pipermail/jdk-updates-dev/2022-February/011862.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8218546](https://bugs.openjdk.java.net/browse/JDK-8218546): Unable to connect to https://google.com using java.net.HttpClient


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.java.net/jdk11u pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u/pull/26.diff">https://git.openjdk.java.net/jdk11u/pull/26.diff</a>

</details>
