### PR TITLE
8280786: Build failure on Solaris after 8262392

### DIFF
--- a/src/java.desktop/unix/native/common/java2d/opengl/J2D_GL/glxext.h
+++ b/src/java.desktop/unix/native/common/java2d/opengl/J2D_GL/glxext.h
@@ -698,8 +698,10 @@ int glXGetVideoInfoNV (Display *dpy, int screen, GLXVideoDeviceNV VideoDevice, u
 /* Define int32_t, int64_t, and uint64_t types for UST/MSC */
 /* (as used in the GLX_OML_sync_control extension). */
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+/* JDK modification */
+#elif defined(__sun__)
 #include <inttypes.h>
-#elif defined(__sun__) || defined(__digital__)
+#elif defined(__digital__)
 #include <inttypes.h>
 #if defined(__STDC__)
 #if defined(__arch64__) || defined(_LP64)


### PR DESCRIPTION
See See http://mail.openjdk.java.net/pipermail/jdk-updates-dev/2022-February/011862.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280786](https://bugs.openjdk.java.net/browse/JDK-8280786): Build failure on Solaris after 8262392


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.java.net/jdk11u pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u/pull/27.diff">https://git.openjdk.java.net/jdk11u/pull/27.diff</a>

</details>
