### PR TITLE
8275703: System.loadLibrary fails on Big Sur for libraries hidden from filesystem

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -83,6 +83,7 @@ ifeq ($(OPENJDK_TARGET_OS), macosx)
 else
   BUILD_JDK_JTREG_EXCLUDE += libTestMainKeyWindow.m
   BUILD_JDK_JTREG_EXCLUDE += libTestDynamicStore.m
+  BUILD_JDK_JTREG_EXCLUDE += exeLibraryCache.c
 endif
 
 $(eval $(call SetupTestFilesCompilation, BUILD_JDK_JTREG_LIBRARIES, \

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -160,7 +160,7 @@ JNIEXPORT jboolean JNICALL
 JVM_IsUseContainerSupport(void);
 
 JNIEXPORT void * JNICALL
-JVM_LoadLibrary(const char *name);
+JVM_LoadLibrary(const char *name, jboolean throwException);
 
 JNIEXPORT void JNICALL
 JVM_UnloadLibrary(void * handle);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3442,7 +3442,7 @@ JVM_END
 
 // Library support ///////////////////////////////////////////////////////////////////////////
 
-JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* name))
+JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* name, jboolean throwException))
   //%note jvm_ct
   JVMWrapper("JVM_LoadLibrary");
   char ebuf[1024];
@@ -3452,18 +3452,22 @@ JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* name))
     load_result = os::dll_load(name, ebuf, sizeof ebuf);
   }
   if (load_result == NULL) {
-    char msg[1024];
-    jio_snprintf(msg, sizeof msg, "%s: %s", name, ebuf);
-    // Since 'ebuf' may contain a string encoded using
-    // platform encoding scheme, we need to pass
-    // Exceptions::unsafe_to_utf8 to the new_exception method
-    // as the last argument. See bug 6367357.
-    Handle h_exception =
-      Exceptions::new_exception(thread,
-                                vmSymbols::java_lang_UnsatisfiedLinkError(),
-                                msg, Exceptions::unsafe_to_utf8);
+    if (throwException) {
+      char msg[1024];
+      jio_snprintf(msg, sizeof msg, "%s: %s", name, ebuf);
+      // Since 'ebuf' may contain a string encoded using
+      // platform encoding scheme, we need to pass
+      // Exceptions::unsafe_to_utf8 to the new_exception method
+      // as the last argument. See bug 6367357.
+      Handle h_exception =
+        Exceptions::new_exception(thread,
+                                  vmSymbols::java_lang_UnsatisfiedLinkError(),
+                                  msg, Exceptions::unsafe_to_utf8);
 
-    THROW_HANDLE_0(h_exception);
+      THROW_HANDLE_0(h_exception);
+    } else {
+      return load_result;
+    }
   }
   return load_result;
 JVM_END

--- a/src/java.base/macosx/classes/java/lang/ClassLoaderHelper.java
+++ b/src/java.base/macosx/classes/java/lang/ClassLoaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,36 @@
 package java.lang;
 
 import java.io.File;
+import sun.security.action.GetPropertyAction;
 
 class ClassLoaderHelper {
+    private static final boolean hasDynamicLoaderCache;
+    static {
+        String osVersion = GetPropertyAction.privilegedGetProperty("os.version");
+        // dynamic linker cache support on os.version >= 11.x
+        int major = 11;
+        int i = osVersion.indexOf('.');
+        try {
+            major = Integer.parseInt(i < 0 ? osVersion : osVersion.substring(0, i));
+        } catch (NumberFormatException e) {}
+        hasDynamicLoaderCache = major >= 11;
+    }
 
     private ClassLoaderHelper() {}
+
+    /**
+     * Returns true if loading a native library only if
+     * it's present on the file system.
+     *
+     * @implNote
+     * On macOS 11.x or later which supports dynamic linker cache,
+     * the dynamic library is not present on the filesystem.  The
+     * library cannot determine if a dynamic library exists on a
+     * given path or not and so this method returns false.
+     */
+    static boolean loadLibraryOnlyIfPresent() {
+        return !hasDynamicLoaderCache;
+    }
 
     /**
      * Indicates, whether PATH env variable is allowed to contain quoted entries.

--- a/src/java.base/share/native/libjava/ClassLoader.c
+++ b/src/java.base/share/native/libjava/ClassLoader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -336,7 +336,8 @@ static void *findJniFunction(JNIEnv *env, void *handle,
  */
 JNIEXPORT jboolean JNICALL
 Java_java_lang_ClassLoader_00024NativeLibrary_load0
-  (JNIEnv *env, jobject this, jstring name, jboolean isBuiltin)
+  (JNIEnv *env, jobject this, jstring name,
+   jboolean isBuiltin, jboolean throwExceptionIfFail)
 {
     const char *cname;
     jint jniVersion;
@@ -350,7 +351,7 @@ Java_java_lang_ClassLoader_00024NativeLibrary_load0
     cname = JNU_GetStringPlatformChars(env, name, 0);
     if (cname == 0)
         return JNI_FALSE;
-    handle = isBuiltin ? procHandle : JVM_LoadLibrary(cname);
+    handle = isBuiltin ? procHandle : JVM_LoadLibrary(cname, throwExceptionIfFail);
     if (handle) {
         JNI_OnLoad_t JNI_OnLoad;
         JNI_OnLoad = (JNI_OnLoad_t)findJniFunction(env, handle,

--- a/src/java.base/unix/classes/java/lang/ClassLoaderHelper.java
+++ b/src/java.base/unix/classes/java/lang/ClassLoaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,14 @@ class ClassLoaderHelper {
      * Indicates, whether PATH env variable is allowed to contain quoted entries.
      */
     static final boolean allowsQuotedPathElements = false;
+
+    /**
+     * Returns true if loading a native library only if
+     * it's present on the file system.
+     */
+    static boolean loadLibraryOnlyIfPresent() {
+        return true;
+    }
 
     /**
      * Returns an alternate path name for the given file

--- a/src/java.base/windows/classes/java/lang/ClassLoaderHelper.java
+++ b/src/java.base/windows/classes/java/lang/ClassLoaderHelper.java
@@ -37,6 +37,14 @@ class ClassLoaderHelper {
     static final boolean allowsQuotedPathElements = true;
 
     /**
+     * Returns true if loading a native library only if
+     * it's present on the file system.
+     */
+    static boolean loadLibraryOnlyIfPresent() {
+        return true;
+    }
+
+    /**
      * Returns an alternate path name for the given file
      * such that if the original pathname did not exist, then the
      * file may be located at the alternate location.

--- a/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
+++ b/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8275703
+ * @library /test/lib
+ * @requires os.family == "mac"
+ * @run main/native/othervm -Djava.library.path=/usr/lib LibraryFromCache blas
+ * @run main/native/othervm -Djava.library.path=/usr/lib LibraryFromCache BLAS
+ * @summary Test System::loadLibrary to be able to load a library even
+ *          if it's not present on the filesystem on macOS which supports
+ *          dynamic library cache
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class LibraryFromCache {
+    public static void main(String[] args) throws IOException {
+        String libname = args[0];
+        if (!systemHasLibrary(libname)) {
+            System.out.println("Test skipped. Library " + libname + " not found");
+            return;
+        }
+
+        System.loadLibrary(libname);
+    }
+
+    /*
+     * Returns true if dlopen successfully loads the specified library
+     */
+    private static boolean systemHasLibrary(String libname) throws IOException {
+        Path launcher = Paths.get(System.getProperty("test.nativepath"), "LibraryCache");
+        ProcessBuilder pb = new ProcessBuilder(launcher.toString(), "lib" + libname + ".dylib");
+        OutputAnalyzer outputAnalyzer = new OutputAnalyzer(pb.start());
+        System.out.println(outputAnalyzer.getOutput());
+        return outputAnalyzer.getExitValue() == 0;
+    }
+}

--- a/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/exeLibraryCache.c
+++ b/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/exeLibraryCache.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+
+int main(int argc, char** argv)
+{
+    void *handle;
+
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <lib_filename_or_full_path>\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    printf("Attempting to load library '%s'...\n", argv[1]);
+
+    handle = dlopen(argv[1], RTLD_LAZY);
+
+    if (handle == NULL) {
+       fprintf(stderr, "Unable to load library!\n");
+       return EXIT_FAILURE;
+    }
+
+    printf("Library successfully loaded!\n");
+
+    return dlclose(handle);
+}


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

The code touched was completely reworked in jdk15 by "8228336: Refactor native library loading implementation"

make/test/JtregNativeJdk.gmk
Trivial resolve due to context.

src/hotspot/share/prims/jvm.cpp
Applies clean, but does not compile.
I removed "log_info(library)("Failed to load library %s", name);"
Logging was only added to this file in jdk15 with "8187305: Add logging for shared library loads/unloads"

Changes to 
src/java.base/macosx/classes/jdk/internal/loader/ClassLoaderHelper.java
applied to 
src/java.base/macosx/classes/java/lang/ClassLoaderHelper.java
Fits well.

Changes to 
src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
applied to class NativeLibrary in java/lang/ClassLoader.java.
I had to modify the code.

Changes to 
src/java.base/share/native/libjava/NativeLibraries.c
applied to 
src/java.base/share/native/libjava/ClassLoader.c
Fits acceptable.

Changes to
src/java.base/unix/classes/jdk/internal/loader/ClassLoaderHelper.java
applied to 
src/java.base/unix/classes/java/lang/ClassLoaderHelper.java
Fits well.

Changes to
src/java.base/windows/classes/jdk/internal/loader/ClassLoaderHelper.java
applied to 
src/java.base/windows/classes/java/lang/ClassLoaderHelper.java
Fits well.

SAP testing passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275703](https://bugs.openjdk.java.net/browse/JDK-8275703): System.loadLibrary fails on Big Sur for libraries hidden from filesystem


### Reviewers
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.java.net/jdk11u pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u/pull/30.diff">https://git.openjdk.java.net/jdk11u/pull/30.diff</a>

</details>
