### PR TITLE
8286594: (zipfs) Mention paths with dot elements in ZipException and cleanups

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -1102,9 +1102,9 @@ class ZipFileSystem extends FileSystem {
                 zerror("invalid CEN header (bad header size)");
             }
             IndexNode inode = new IndexNode(cen, pos, nlen);
-            if (hasDotOrDotDot(inode.name)) {
+            if (inode.pathHasDotOrDotDot()) {
                 throw new ZipException("ZIP file can't be opened as a file system " +
-                        "because an entry has a '.' or '..' element in its name");
+                        "because entry \"" + inode.nameAsString() + "\" has a '.' or '..' element in its name");
             }
             inodes.put(inode, inode);
             if (zc.isUTF8() || (flag & FLAG_USE_UTF8) != 0) {
@@ -1120,44 +1120,6 @@ class ZipFileSystem extends FileSystem {
         }
         buildNodeTree();
         return cen;
-    }
-
-    /**
-     * Check Inode.name to see if it includes a "." or ".." in the name array
-     * @param path  the path as stored in Inode.name to verify
-     * @return true if the path contains a "." or ".." entry; false otherwise
-     */
-    private boolean hasDotOrDotDot(byte[] path) {
-        // Inode.name always includes "/" in path[0]
-        assert path[0] == '/';
-        if (path.length == 1) {
-            return false;
-        }
-        int index = 1;
-        while (index < path.length) {
-            int starting = index;
-            while (index < path.length && path[index] != '/') {
-                index++;
-            }
-            // Check the path snippet for a "." or ".."
-            if (isDotOrDotDotPath(path, starting, index)) {
-                return true;
-            }
-            index++;
-        }
-        return false;
-    }
-
-    /**
-     * Check the path to see if it includes a "." or ".."
-     * @param path  the path to check
-     * @return true if the path contains a "." or ".." entry; false otherwise
-     */
-    private boolean isDotOrDotDotPath(byte[] path, int start, int index) {
-        int pathLen = index - start;
-        if ((pathLen == 1 && path[start] == '.'))
-            return true;
-        return (pathLen == 2 && path[start] == '.') && path[start + 1] == '.';
     }
 
     private  final void checkUTF8(byte[] a) throws ZipException {
@@ -2181,6 +2143,37 @@ class ZipFileSystem extends FileSystem {
             return isdir;
         }
 
+        /**
+         * Check name if it contains a "." or ".." path element
+         * @return true if the path contains a "." or ".." entry; false otherwise
+         */
+        private boolean pathHasDotOrDotDot() {
+            // name always includes "/" in path[0]
+            assert name[0] == '/';
+            if (name.length == 1) {
+                return false;
+            }
+            int index = 1;
+            while (index < name.length) {
+                int start = index;
+                while (index < name.length && name[index] != '/') {
+                    index++;
+                }
+                if (name[start] == '.') {
+                    int len = index - start;
+                    if (len == 1 || (name[start + 1] == '.' && len == 2)) {
+                        return true;
+                    }
+                }
+                index++;
+            }
+            return false;
+        }
+
+        protected String nameAsString() {
+            return new String(name);
+        }
+
         public boolean equals(Object other) {
             if (!(other instanceof IndexNode)) {
                 return false;
@@ -2751,7 +2744,7 @@ class ZipFileSystem extends FileSystem {
         public String toString() {
             StringBuilder sb = new StringBuilder(1024);
             Formatter fm = new Formatter(sb);
-            fm.format("    name            : %s%n", new String(name));
+            fm.format("    name            : %s%n", nameAsString());
             fm.format("    creationTime    : %tc%n", creationTime().toMillis());
             fm.format("    lastAccessTime  : %tc%n", lastAccessTime().toMillis());
             fm.format("    lastModifiedTime: %tc%n", lastModifiedTime().toMillis());


### PR DESCRIPTION
The backport needed some resolving/adaptation to older zipfs code.
Method IndexNode:toString is not implemented, so this part of the upstream patch does not apply.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286594](https://bugs.openjdk.java.net/browse/JDK-8286594): (zipfs) Mention paths with dot elements in ZipException and cleanups


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.java.net/jdk11u pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u/pull/38.diff">https://git.openjdk.java.net/jdk11u/pull/38.diff</a>

</details>
