### PR TITLE
Backport be1007cfafd63e61541fd94a15c104c7bc54fe0d

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -813,6 +813,8 @@ com/sun/jdi/RepStep.java                                        8043571 generic-
 
 com/sun/jdi/NashornPopFrameTest.java                            8187143 generic-all
 
+com/sun/jdi/InvokeHangTest.java                                 8218463 linux-all
+
 ############################################################################
 
 # jdk_time


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8240132] (https://bugs.openjdk.java.net/browse/JDK-8240132), commit [be1007cf](https://github.com/openjdk/jdk/commit/be1007cfafd63e61541fd94a15c104c7bc54fe0d) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Daniel D. Daugherty on 27 Feb 2020 and was reviewed by Mikael Vidstedt.

Thanks!