### PR TITLE
8287739: [11u] ProblemList sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -660,7 +660,7 @@ javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
-sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java 8277970 linux-all,macosx-x64
+sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java 8277970,8280158 generic-all
 
 sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java    8287109 generic-all
 


### PR DESCRIPTION
Let's problem list sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java on all platforms since it's constantly failing and no solution for JDK-8280158 is in sight.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287739](https://bugs.openjdk.java.net/browse/JDK-8287739): [11u] ProblemList sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.java.net/jdk11u pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u/pull/43.diff">https://git.openjdk.java.net/jdk11u/pull/43.diff</a>

</details>
