### PR TITLE
8285515: (dc) DatagramChannel.disconnect fails with "Invalid argument" on macOS 12.4

### DIFF
--- a/src/java.base/unix/native/libnio/ch/DatagramChannelImpl.c
+++ b/src/java.base/unix/native/libnio/ch/DatagramChannelImpl.c
@@ -89,21 +89,29 @@ Java_sun_nio_ch_DatagramChannelImpl_disconnect0(JNIEnv *env, jobject this,
 
 #if defined(__solaris__)
     rv = connect(fd, 0, 0);
+#elif defined(__APPLE__)
+    // On macOS systems we use disconnectx
+    rv = disconnectx(fd, SAE_ASSOCID_ANY, SAE_CONNID_ANY);
 #else
     SOCKETADDRESS sa;
-    socklen_t len = isIPv6 ? sizeof(struct sockaddr_in6) :
-                             sizeof(struct sockaddr_in);
-
     memset(&sa, 0, sizeof(sa));
 #if defined(_ALLBSD_SOURCE)
     sa.sa.sa_family = isIPv6 ? AF_INET6 : AF_INET;
 #else
     sa.sa.sa_family = AF_UNSPEC;
 #endif
+    socklen_t len = isIPv6 ? sizeof(struct sockaddr_in6) :
+                             sizeof(struct sockaddr_in);
 
     rv = connect(fd, &sa.sa, len);
+#endif
 
-#if defined(_ALLBSD_SOURCE)
+#if defined(_ALLBSD_SOURCE) && !defined(__APPLE__)
+    // On _ALLBSD_SOURCE except __APPLE__ we consider EADDRNOTAVAIL
+    // error to be OK and ignore it. __APPLE__ systems are excluded
+    // in this check since for __APPLE__ systems, unlike other BSD systems,
+    // we issue a "disconnectx" call (a few lines above),
+    // which isn't expected to return this error code.
     if (rv < 0 && errno == EADDRNOTAVAIL)
         rv = errno = 0;
 #elif defined(_AIX)
@@ -114,8 +122,6 @@ Java_sun_nio_ch_DatagramChannelImpl_disconnect0(JNIEnv *env, jobject this,
     if (rv < 0 && errno == EAFNOSUPPORT)
         rv = errno = 0;
 #endif // defined(_ALLBSD_SOURCE) || defined(_AIX)
-
-#endif // defined(__solaris__)
 
     if (rv < 0)
         handleSocketError(env, errno);

--- a/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 7132924
+ * @bug 7132924 8285515
  * @key intermittent
  * @summary Test DatagramChannel.disconnect when DatagramChannel is connected to an IPv4 socket
  * @run main Disconnect


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

I had to resolve DatagramChannelImpl.c because 11 has Solaris specific code in the context.
The test has a different @test description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285515](https://bugs.openjdk.org/browse/JDK-8285515): (dc) DatagramChannel.disconnect fails with "Invalid argument" on macOS 12.4


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.org/jdk11u pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/46.diff">https://git.openjdk.org/jdk11u/pull/46.diff</a>

</details>
