### PR TITLE
8230708: Hotspot fails to build on linux-sparc with gcc-9

### DIFF
--- a/src/hotspot/cpu/sparc/nativeInst_sparc.hpp
+++ b/src/hotspot/cpu/sparc/nativeInst_sparc.hpp
@@ -313,7 +313,7 @@ inline NativeInstruction* nativeInstruction_at(address address) {
 // (used to manipulate inline caches, primitive & dll calls, etc.)
 inline NativeCall* nativeCall_at(address instr);
 inline NativeCall* nativeCall_overwriting_at(address instr,
-                                             address destination);
+                                             address destination = NULL);
 inline NativeCall* nativeCall_before(address return_address);
 class NativeCall: public NativeInstruction {
  public:
@@ -342,7 +342,7 @@ class NativeCall: public NativeInstruction {
 
   // Creation
   friend inline NativeCall* nativeCall_at(address instr);
-  friend NativeCall* nativeCall_overwriting_at(address instr, address destination = NULL) {
+  friend NativeCall* nativeCall_overwriting_at(address instr, address destination) {
     // insert a "blank" call:
     NativeCall* call = (NativeCall*)instr;
     call->set_long_at(0 * BytesPerInstWord, call_instruction(destination, instr));
@@ -411,7 +411,7 @@ class NativeCallReg: public NativeInstruction {
 //      == sethi %hi54(addr), O7 ;  jumpl O7, %lo10(addr), O7 ;  <delay>
 // That is, it is essentially the same as a NativeJump.
 class NativeFarCall;
-inline NativeFarCall* nativeFarCall_overwriting_at(address instr, address destination);
+inline NativeFarCall* nativeFarCall_overwriting_at(address instr, address destination = NULL);
 inline NativeFarCall* nativeFarCall_at(address instr);
 class NativeFarCall: public NativeInstruction {
  public:
@@ -450,7 +450,7 @@ class NativeFarCall: public NativeInstruction {
     return call;
   }
 
-  friend inline NativeFarCall* nativeFarCall_overwriting_at(address instr, address destination = NULL) {
+  friend inline NativeFarCall* nativeFarCall_overwriting_at(address instr, address destination) {
     Unimplemented();
     NativeFarCall* call = (NativeFarCall*)instr;
     return call;


### PR DESCRIPTION
This patch fixes compiling jdk11 to linux/sparc64 with GGC9 or higher [(bug 8230708)](https://bugs.openjdk.org/browse/JDK-8230708). I did not write this patch, the patch I used is [here](https://hg.openjdk.java.net/jdk/jdk/rev/9fba708740d6), but the fix only applied to jdk14 despite effecting jdk11 also. This patch worked for me and at least one other sparc user I talked to.

I do not believe I need to sign the OCA, as this patch is not my IP, and has already been merged into a later OpenJDK version. If I'm incorrect, feel free to let me know.

This should be fairly low risk: it only touches sparc-specific code.

I appreciate your time :^)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8230708](https://bugs.openjdk.org/browse/JDK-8230708): Hotspot fails to build on linux-sparc with gcc-9 ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.org/jdk11u pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/51.diff">https://git.openjdk.org/jdk11u/pull/51.diff</a>

</details>
