### PR TITLE
8292434: javadoc generation fails if javadoc contains @see with generics

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTrees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.util.List;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
+import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.JavaCompiler.CompilationTask;
@@ -151,6 +152,21 @@ public abstract class DocTrees extends Trees {
      * @return the element
      */
     public abstract Element getElement(DocTreePath path);
+
+    /**
+     * Returns the language model type referred to by the leaf node of the given
+     * {@link DocTreePath}, or {@code null} if unknown. This method usually
+     * returns the same value as {@code getElement(path).asType()} for a
+     * {@code path} argument for which {@link #getElement(DocTreePath)} returns
+     * a non-null value, but may return a type that includes additional
+     * information, such as a parameterized generic type instead of a raw type.
+     *
+     * @param path the path for the tree node
+     * @return the referenced type, or null
+     *
+     * @since 11
+     */
+    public abstract TypeMirror getType(DocTreePath path);
 
     /**
      * Returns the list of {@link DocTree} representing the first sentence of

--- a/src/jdk.compiler/share/classes/com/sun/tools/doclint/Checker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/doclint/Checker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -866,14 +866,11 @@ public class Checker extends DocTreePathScanner<Void, Void> {
 
     @Override @DefinedBy(Api.COMPILER_TREE)
     public Void visitReference(ReferenceTree tree, Void ignore) {
-        String sig = tree.getSignature();
-        if (sig.contains("<") || sig.contains(">")) {
-            env.messages.error(REFERENCE, tree, "dc.type.arg.not.allowed");
-        } else {
-            Element e = env.trees.getElement(getCurrentPath());
-            if (e == null)
-                env.messages.error(REFERENCE, tree, "dc.ref.not.found");
+        Element e = env.trees.getElement(getCurrentPath());
+        if (e == null) {
+            env.messages.error(REFERENCE, tree, "dc.ref.not.found");
         }
+
         return super.visitReference(tree, ignore);
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/doclint/resources/doclint.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/doclint/resources/doclint.properties
@@ -78,7 +78,6 @@ dc.tag.start.unmatched = end tag missing: </{0}>
 dc.tag.unknown = unknown tag: {0}
 dc.tag.not.supported = tag not supported in the generated HTML version: {0}
 dc.text.not.allowed = text not allowed in <{0}> element
-dc.type.arg.not.allowed = type arguments not allowed here
 dc.unexpected.comment=documentation comment not expected here
 dc.value.not.allowed.here='{@value}' not allowed here
 dc.value.not.a.constant=value does not refer to a constant

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -421,6 +421,31 @@ public class JavacTrees extends DocTrees {
     }
 
     @Override @DefinedBy(Api.COMPILER_TREE)
+    public TypeMirror getType(DocTreePath path) {
+        DocTree tree = path.getLeaf();
+        if (tree instanceof DCReference) {
+            JCTree qexpr = ((DCReference)tree).qualifierExpression;
+            if (qexpr != null) {
+                Log.DeferredDiagnosticHandler deferredDiagnosticHandler =
+                        new Log.DeferredDiagnosticHandler(log);
+                try {
+                    Env<AttrContext> env = getAttrContext(path.getTreePath());
+                    Type t = attr.attribType(((DCReference) tree).qualifierExpression, env);
+                    if (t != null && !t.isErroneous()) {
+                        return t;
+                    }
+                } catch (Abort e) { // may be thrown by Check.completionError in case of bad class file
+                    return null;
+                } finally {
+                    log.popDiagnosticHandler(deferredDiagnosticHandler);
+                }
+            }
+        }
+        Element e = getElement(path);
+        return e == null ? null : e.asType();
+    }
+
+    @Override @DefinedBy(Api.COMPILER_TREE)
     public java.util.List<DocTree> getFirstSentence(java.util.List<? extends DocTree> list) {
         return docTreeMaker.getFirstSentence(list);
     }
@@ -705,80 +730,18 @@ public class JavacTrees extends DocTrees {
         if (paramTypes == null)
             return true;
 
-        if (method.params().size() != paramTypes.size())
+        if (method.params().size() != paramTypes.size()) {
             return false;
+        }
 
-        List<Type> methodParamTypes = types.erasureRecursive(method.asType()).getParameterTypes();
+        List<Type> methodParamTypes = method.asType().getParameterTypes();
+        if (!Type.isErroneous(paramTypes) && types.isSubtypes(paramTypes, methodParamTypes)) {
+            return true;
+        }
 
-        return (Type.isErroneous(paramTypes))
-            ? fuzzyMatch(paramTypes, methodParamTypes)
-            : types.isSameTypes(paramTypes, methodParamTypes);
+        methodParamTypes = types.erasureRecursive(methodParamTypes);
+        return types.isSameTypes(paramTypes, methodParamTypes);
     }
-
-    boolean fuzzyMatch(List<Type> paramTypes, List<Type> methodParamTypes) {
-        List<Type> l1 = paramTypes;
-        List<Type> l2 = methodParamTypes;
-        while (l1.nonEmpty()) {
-            if (!fuzzyMatch(l1.head, l2.head))
-                return false;
-            l1 = l1.tail;
-            l2 = l2.tail;
-        }
-        return true;
-    }
-
-    boolean fuzzyMatch(Type paramType, Type methodParamType) {
-        Boolean b = fuzzyMatcher.visit(paramType, methodParamType);
-        return (b == Boolean.TRUE);
-    }
-
-    TypeRelation fuzzyMatcher = new TypeRelation() {
-        @Override
-        public Boolean visitType(Type t, Type s) {
-            if (t == s)
-                return true;
-
-            if (s.isPartial())
-                return visit(s, t);
-
-            switch (t.getTag()) {
-            case BYTE: case CHAR: case SHORT: case INT: case LONG: case FLOAT:
-            case DOUBLE: case BOOLEAN: case VOID: case BOT: case NONE:
-                return t.hasTag(s.getTag());
-            default:
-                throw new AssertionError("fuzzyMatcher " + t.getTag());
-            }
-        }
-
-        @Override
-        public Boolean visitArrayType(ArrayType t, Type s) {
-            if (t == s)
-                return true;
-
-            if (s.isPartial())
-                return visit(s, t);
-
-            return s.hasTag(ARRAY)
-                && visit(t.elemtype, types.elemtype(s));
-        }
-
-        @Override
-        public Boolean visitClassType(ClassType t, Type s) {
-            if (t == s)
-                return true;
-
-            if (s.isPartial())
-                return visit(s, t);
-
-            return t.tsym == s.tsym;
-        }
-
-        @Override
-        public Boolean visitErrorType(ErrorType t, Type s) {
-            return s.hasTag(CLASS)
-                    && t.tsym.name == ((ClassType) s).tsym.name;
-        }
-    };
 
     @Override @DefinedBy(Api.COMPILER_TREE)
     public TypeMirror getTypeMirror(TreePath path) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1035,19 +1035,15 @@ public class HtmlDocletWriter {
         } else if (refMemName == null) {
             // Must be a class reference since refClass is not null and refMemName is null.
             if (label.isEmpty()) {
-                /*
-                 * it seems to me this is the right thing to do, but it causes comparator failures.
-                 */
-                if (!configuration.backwardCompatibility) {
-                    StringContent content = utils.isEnclosingPackageIncluded(refClass)
-                            ? new StringContent(utils.getSimpleName(refClass))
-                            : new StringContent(utils.getFullyQualifiedName(refClass));
-                    label = plainOrCode(isLinkPlain, content);
-                } else {
-                    label = plainOrCode(isLinkPlain,
-                            new StringContent(utils.getSimpleName(refClass)));
+                if (!refClass.getTypeParameters().isEmpty() && seetext.contains("<")) {
+                    // If this is a generic type link try to use the TypeMirror representation.
+                    TypeMirror refType = ch.getReferencedType(see);
+                    if (refType != null) {
+                        return plainOrCode(isLinkPlain, getLink(
+                                new LinkInfoImpl(configuration, LinkInfoImpl.Kind.DEFAULT, refType)));
+                    }
                 }
-
+                label = plainOrCode(isLinkPlain, new StringContent(utils.getSimpleName(refClass)));
             }
             return getLink(new LinkInfoImpl(configuration, LinkInfoImpl.Kind.DEFAULT, refClass)
                     .label(label));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkFactoryImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -147,7 +147,7 @@ public class LinkFactoryImpl extends LinkFactory {
             ((DeclaredType)linkInfo.type).getTypeArguments().stream().forEach(vars::add);
         } else if (ctype != null && utils.isDeclaredType(ctype)) {
             ((DeclaredType)ctype).getTypeArguments().stream().forEach(vars::add);
-        } else if (linkInfo.typeElement != null) {
+        } else if (ctype == null && linkInfo.typeElement != null) {
             linkInfo.typeElement.getTypeParameters().stream().forEach((t) -> {
                 vars.add(t.asType());
             });

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/LinkInfoImpl.java
@@ -188,11 +188,6 @@ public class LinkInfoImpl extends LinkInfo {
         ANNOTATION,
 
         /**
-         * The header for field documentation copied from parent.
-         */
-        VARIABLE_ELEMENT_COPY,
-
-        /**
          * The parent nodes in the class tree.
          */
         CLASS_TREE_PARENT,
@@ -358,7 +353,6 @@ public class LinkInfoImpl extends LinkInfo {
             case IMPLEMENTED_CLASSES:
             case SUBCLASSES:
             case EXECUTABLE_ELEMENT_COPY:
-            case VARIABLE_ELEMENT_COPY:
             case PROPERTY_COPY:
             case CLASS_USE_HEADER:
                 includeTypeInClassLinkLabel = false;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
@@ -138,11 +138,6 @@ public abstract class BaseConfiguration {
     public boolean copydocfilesubdirs = false;
 
     /**
-     * Maintain backward compatibility with previous javadoc version
-     */
-    public boolean backwardCompatibility = true;
-
-    /**
      * True if user wants to add member names as meta keywords.
      * Set to false because meta keywords are ignored in general
      * by most Internet search engines.

--- a/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/TestGenericTypeLink.java
+++ b/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/TestGenericTypeLink.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug     8177280
+ * @summary see and link tag syntax should allow generic types
+ * @library ../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build JavadocTester
+ * @run main TestGenericTypeLink
+ */
+
+public class TestGenericTypeLink extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestGenericTypeLink test = new TestGenericTypeLink();
+        test.runTests();
+    }
+
+    /**
+     * Test valid internal and external links to generic types.
+     */
+    @Test
+    public void testValidLinks() {
+        javadoc("-d", "out1",
+                "-sourcepath", testSrc,
+                "-linkoffline", "http://example.com/docs/api/", testSrc,
+                "-package", "pkg1");
+        checkExit(Exit.OK);
+        checkOutput("pkg1/A.html", true,
+                "<div class=\"block\"><code><a href=\"http://example.com/docs/api/java.base"
+                + "/java/util/List.html?is-external=true\" title=\"class or interface in java.util\" "
+                + "class=\"externalLink\">List</a>&lt;<a href=\"http://example.com/docs/api/"
+                + "java.base/java/lang/String.html?is-external=true\" title=\"class or interface in java.lang\" "
+                + "class=\"externalLink\">String</a>&gt;</code>\n"
+                + " <a href=\"http://example.com/docs/api/java.base/java/util/"
+                + "List.html?is-external=true\" title=\"class or interface in java.util\" class=\"externalLink\">"
+                + "List</a>&lt;? extends <a href=\"http://example.com/docs/api/java.base/"
+                + "java/lang/CharSequence.html?is-external=true\" title=\"class or interface in java.lang\" "
+                + "class=\"externalLink\">CharSequence</a>&gt;\n"
+                + " <a href=\"#someMethod(java.util.List,int)\"><code>someMethod("
+                + "ArrayList&lt;Integer&gt;, int)</code></a>\n"
+                + " <a href=\"#otherMethod(java.util.Map,double)\"><code>otherMethod("
+                + "Map&lt;String, StringBuilder&gt;, double)</code></a></div>\n",
+
+                "<dl>\n"
+                + "<dt><span class=\"seeLabel\">See Also:</span></dt>\n"
+                + "<dd><code><a href=\"http://example.com/docs/api/java.base/"
+                + "java/util/Map.html?is-external=true\" title=\"class or interface in java.util\" "
+                + "class=\"externalLink\">Map</a>&lt;<a href=\"http://example.com/"
+                + "docs/api/java.base/java/lang/String.html?is-external=true\" title=\"class or interface "
+                + "in java.lang\" class=\"externalLink\">String</a>,&#8203;? extends "
+                + "<a href=\"http://example.com/docs/api/java.base/"
+                + "java/lang/CharSequence.html?is-external=true\" title=\"class or interface in "
+                + "java.lang\" class=\"externalLink\">CharSequence</a>&gt;</code>, \n"
+                + "<code><a href=\"http://example.com/docs/api/java.base/"
+                + "java/util/Map.html?is-external=true\" title=\"class or interface in java.util\" "
+                + "class=\"externalLink\">Map</a>&lt;<a href=\"http://example.com/docs/api/"
+                + "java.base/java/lang/String.html?is-external=true\" title=\"class or interface in java.lang\" "
+                + "class=\"externalLink\">String</a>,&#8203;? super <a href=\"A.html\" title=\"class in pkg1\">"
+                + "A</a>&lt;<a href=\"http://example.com/docs/api/java.base/"
+                + "java/lang/String.html?is-external=true\" title=\"class or interface in java.lang\" "
+                + "class=\"externalLink\">String</a>,&#8203;? extends <a href=\"http://example.com/docs/api"
+                + "/java.base/java/lang/RuntimeException.html?is-external=true\" "
+                + "title=\"class or interface in java.lang\" class=\"externalLink\">RuntimeException</a>"
+                + "&gt;&gt;</code>, \n"
+                + "<a href=\"#someMethod(java.util.List,int)\"><code>someMethod"
+                + "(List&lt;Number&gt;, int)</code></a>, \n"
+                + "<a href=\"#otherMethod(java.util.Map,double)\"><code>otherMethod"
+                + "(Map&lt;String, ? extends CharSequence&gt;, double)</code></a></dd>\n"
+                + "</dl>"
+                );
+        checkOutput("pkg1/A.SomeException.html", true,
+                "<div class=\"block\"><code><a href=\"A.html\" title=\"class in pkg1\">A</a>&lt;"
+                + "<a href=\"http://example.com/docs/api/java.base/java/lang/String.html?is-external=true"
+                + "\" title=\"class or interface in java.lang\" class=\"externalLink\">String</a>"
+                + ",&#8203;<a href=\"A.SomeException.html\" title=\"class in pkg1\">A.SomeException</a>&gt;</code>\n"
+                + " <a href=\"http://example.com/docs/api/java.base/java/util/Map.html?is-external=true"
+                + "\" title=\"class or interface in java.util\" class=\"externalLink\">"
+                + "link to generic type with label</a></div>",
+
+                "<dl>\n"
+                + "<dt><span class=\"seeLabel\">See Also:</span></dt>\n"
+                + "<dd><code><a href=\"A.html\" title=\"class in pkg1\">A</a>&lt;<a href=\"http://example.com/docs/api"
+                + "/java.base/java/lang/String.html?is-external=true\" "
+                + "title=\"class or interface in java.lang\" class=\"externalLink\">String</a>"
+                + ",&#8203;<a href=\"A.SomeException.html\" title=\"class in pkg1\">A.SomeException</a>&gt;</code>, \n"
+                + "<a href=\"http://example.com/docs/api/java.base/"
+                + "java/util/List.html?is-external=true\" title=\"class or interface in java.util\" "
+                + "class=\"externalLink\"><code>Link to generic type with label</code></a></dd>\n"
+                + "</dl>"
+                );
+    }
+
+    /**
+     * Test invalid links to generic types.
+     */
+    @Test
+    public void testInvalidLinks() {
+        javadoc("-d", "out2",
+                "-sourcepath", testSrc,
+                "-linkoffline", "http://example.com/docs/api/", testSrc,
+                "-package", "pkg2");
+        checkExit(Exit.ERROR);
+        checkOutput("pkg2/B.html", true,
+                "<div class=\"block\"><code>java.util.Foo<String></code>\n"
+                + " Baz<Object>\n"
+                + " <code>#b(List<Integer>)</code></div>",
+
+                "<dl>\n"
+                + "<dt><span class=\"seeLabel\">See Also:</span></dt>\n"
+                + "<dd><code>java.util.List<Bar></code>, \n"
+                + "<code>Baz<Object, String></code>, \n"
+                + "<code>B#b(List<Baz>)</code></dd>\n</dl>");
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/element-list
+++ b/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/element-list
@@ -1,0 +1,4 @@
+module:java.base
+java.io
+java.lang
+java.util

--- a/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/pkg1/A.java
+++ b/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/pkg1/A.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg1;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link List<String>}
+ * {@linkplain List<? extends CharSequence>}
+ * {@link #someMethod(ArrayList<Integer>, int)}
+ * {@link A#otherMethod(Map<String, StringBuilder>, double)}
+ *
+ * @see Map<String, ? extends CharSequence>
+ * @see Map<String, ? super A<String, ? extends RuntimeException>>
+ * @see #someMethod(List<Number>, int)
+ * @see #otherMethod(Map<String, ? extends CharSequence>, double)
+ */
+public class A<T, E extends Exception> {
+
+    /**
+     * {@link A<String, A.SomeException>}
+     * {@linkplain Map<String, ? extends CharSequence> link to generic type with label}
+     *
+     * @see A<String, A.SomeException>
+     * @see List<String> Link to generic type with label
+     */
+    static class SomeException extends Exception {}
+
+    /**
+     * @param list a list
+     * @param i an int
+     */
+    public void someMethod(List<? extends Number> list, int i) {}
+
+    /**
+     * @param list a list
+     * @param d a double
+     */
+    public void otherMethod(Map<String, ?> list, double d) {}
+
+    /**
+     * Here's a generic link: {@link A<Object, RuntimeException>.Inner}
+     */
+    public void overriddenMethod() {}
+
+    /**
+     * @see A<String, java.lang.RuntimeException>.Inner
+     * @see A<A<String, java.lang.RuntimeException>.Inner, A.SomeException>
+     */
+    class Inner {}
+
+}
+
+

--- a/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/pkg2/B.java
+++ b/test/langtools/jdk/javadoc/doclet/testGenericTypeLink/pkg2/B.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg2;
+
+import java.util.List;
+
+/**
+ * {@link java.util.Foo<String>}
+ * {@linkplain Baz<Object>}
+ * {@link #b(List<Integer>)}
+ *
+ * @see java.util.List<Bar>
+ * @see Baz<Object, String>
+ * @see B#b(List<Baz>)
+ */
+public class B {
+
+    public static void b(List<? extends CharSequence> l) {}
+}

--- a/test/langtools/tools/doclint/ReferenceTest.java
+++ b/test/langtools/tools/doclint/ReferenceTest.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8004832 8020556 8002154 8200432
+ * @bug 8004832 8020556 8002154 8200432 8177280
  * @summary Add new doclint package
  * @modules jdk.compiler/com.sun.tools.doclint
  * @build DocLintTester

--- a/test/langtools/tools/doclint/ReferenceTest.out
+++ b/test/langtools/tools/doclint/ReferenceTest.out
@@ -25,22 +25,10 @@ ReferenceTest.java:44: error: invalid use of @return
 ReferenceTest.java:49: error: exception not thrown: java.lang.Exception
      * @throws Exception description
                ^
-ReferenceTest.java:60: error: type arguments not allowed here
-     * {@link java.util.List<String>}
-              ^
-ReferenceTest.java:61: error: type arguments not allowed here
-     * {@link java.util.List<String>#equals}
-              ^
-ReferenceTest.java:62: error: type arguments not allowed here
+ReferenceTest.java:62: error: reference not found
      * {@link not.Found<String>}
               ^
-ReferenceTest.java:63: error: type arguments not allowed here
-     * @see java.util.List<String>
-            ^
-ReferenceTest.java:64: error: type arguments not allowed here
-     * @see java.util.List<String>#equals
-            ^
-ReferenceTest.java:65: error: type arguments not allowed here
+ReferenceTest.java:65: error: reference not found
      * @see not.Found<String>
             ^
 ReferenceTest.java:72: error: reference not found
@@ -49,6 +37,5 @@ ReferenceTest.java:72: error: reference not found
 ReferenceTest.java:75: error: reference not found
      * @see not.Found[]
             ^
-16 errors
+12 errors
 1 warning
-


### PR DESCRIPTION
This is a backport of JDK-8177280.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292434](https://bugs.openjdk.org/browse/JDK-8292434): javadoc generation fails if javadoc contains @see with generics


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u pull/61/head:pull/61` \
`$ git checkout pull/61`

Update a local copy of the PR: \
`$ git checkout pull/61` \
`$ git pull https://git.openjdk.org/jdk11u pull/61/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 61`

View PR using the GUI difftool: \
`$ git pr show -t 61`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/61.diff">https://git.openjdk.org/jdk11u/pull/61.diff</a>

</details>
