### PR TITLE
8258005: JDK build fails with incorrect fixpath script

### DIFF
--- a/make/autoconf/basic_windows.m4
+++ b/make/autoconf/basic_windows.m4
@@ -121,7 +121,7 @@ AC_DEFUN([BASIC_SETUP_PATHS_WINDOWS],
   else
     WINENV_PREFIX_ARG="$WINENV_PREFIX"
   fi
-  FIXPATH_ARGS="-e $PATHTOOL -p $WINENV_PREFIX_ARG -r ${WINENV_ROOT/\\/\\\\}  -t $WINENV_TEMP_DIR -c $CMD -q"
+  FIXPATH_ARGS="-e $PATHTOOL -p $WINENV_PREFIX_ARG -r ${WINENV_ROOT//\\/\\\\}  -t $WINENV_TEMP_DIR -c $CMD -q"
   FIXPATH_BASE="$BASH $FIXPATH_DIR/fixpath.sh $FIXPATH_ARGS"
   FIXPATH="$FIXPATH_BASE exec"
 
@@ -166,7 +166,7 @@ AC_DEFUN([BASIC_WINDOWS_FINALIZE_FIXPATH],
 [
   if test "x$OPENJDK_BUILD_OS" = xwindows; then
     FIXPATH_CMDLINE=". $TOPDIR/make/scripts/fixpath.sh -e $PATHTOOL \
-        -p $WINENV_PREFIX_ARG -r ${WINENV_ROOT/\\/\\\\}  -t $WINENV_TEMP_DIR \
+        -p $WINENV_PREFIX_ARG -r ${WINENV_ROOT//\\/\\\\}  -t $WINENV_TEMP_DIR \
         -c $CMD -q"
     $ECHO >  $OUTPUTDIR/fixpath '#!/bin/bash'
     $ECHO >> $OUTPUTDIR/fixpath export PATH='"[$]PATH:'$PATH'"'


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8258005](https://bugs.openjdk.org/browse/JDK-8258005), commit [07399029](https://github.com/openjdk/jdk11u-dev/commit/07399029d7fc80a5104791c4abbb2d36be7e620c) from the [openjdk/jdk11u-dev](https://git.openjdk.org/jdk11u-dev) repository.

The commit being backported was authored by Dan Lutker on 6 Dec 2022 and had no reviewers.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8258005](https://bugs.openjdk.org/browse/JDK-8258005): JDK build fails with incorrect fixpath script


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u pull/62/head:pull/62` \
`$ git checkout pull/62`

Update a local copy of the PR: \
`$ git checkout pull/62` \
`$ git pull https://git.openjdk.org/jdk11u pull/62/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 62`

View PR using the GUI difftool: \
`$ git pr show -t 62`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/62.diff">https://git.openjdk.org/jdk11u/pull/62.diff</a>

</details>
