### PR TITLE
8298737: 8296772 backport to jdk11u caused build error on sparc

### DIFF
--- a/src/hotspot/cpu/sparc/frame_sparc.inline.hpp
+++ b/src/hotspot/cpu/sparc/frame_sparc.inline.hpp
@@ -70,6 +70,10 @@ inline int frame::frame_size(RegisterMap* map) const { return sender_sp() - sp()
 
 inline intptr_t* frame::link() const { return (intptr_t *)(fp()[FP->sp_offset_in_saved_window()] + STACK_BIAS); }
 
+inline intptr_t* frame::link_or_null() const {
+  return link();
+}
+
 inline intptr_t* frame::unextended_sp() const { return sp() + _sp_adjustment_by_callee; }
 
 // return address:


### PR DESCRIPTION
This PR fixes a build regression on Solaris Sparc caused by JDK-8296772

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298737](https://bugs.openjdk.org/browse/JDK-8298737): 8296772 backport to jdk11u caused build error on sparc


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/jdk11u pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/64.diff">https://git.openjdk.org/jdk11u/pull/64.diff</a>

</details>
