### PR TITLE
8280890: Cannot use '-Djava.system.class.loader' with class loader in signed JAR

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -59,8 +59,6 @@ import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.ECParameterSpec;
 import java.text.Collator;
 import java.text.MessageFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -4847,17 +4845,6 @@ public final class Main {
                         throw new Exception(rb.getString(
                                 "Unable.to.parse.denyAfter.string.in.exception.message"));
                     }
-
-                    SimpleDateFormat formatter = new SimpleDateFormat("EEE MMM dd HH:mm:ss Z yyyy");
-                    Date dateObj = null;
-                    try {
-                        dateObj = formatter.parse(denyAfterDate);
-                    } catch (ParseException e2) {
-                        throw new Exception(rb.getString(
-                                "Unable.to.parse.denyAfter.string.in.exception.message"));
-                    }
-                    formatter = new SimpleDateFormat("yyyy-MM-dd");
-                    denyAfterDate = formatter.format(dateObj);
 
                     weakWarnings.add(String.format(
                             rb.getString("whose.sigalg.usagesignedjar"), label, sigAlg,

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,9 +40,12 @@ import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.NamedParameterSpec;
 import java.security.spec.PSSParameterSpec;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -52,7 +55,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Collection;
 import java.util.StringTokenizer;
-import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
@@ -691,41 +693,30 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
      * timezone.
      */
     private static class DenyAfterConstraint extends Constraint {
-        private Date denyAfterDate;
+        private ZonedDateTime zdt;
+        private Instant denyAfterDate;
 
         DenyAfterConstraint(String algo, int year, int month, int day) {
-            Calendar c;
 
             algorithm = algo;
 
             if (debug != null) {
-                debug.println("DenyAfterConstraint read in as:  year " +
+                debug.println("DenyAfterConstraint read in as: year " +
                         year + ", month = " + month + ", day = " + day);
             }
 
-            c = new Calendar.Builder().setTimeZone(TimeZone.getTimeZone("GMT"))
-                    .setDate(year, month - 1, day).build();
-
-            if (year > c.getActualMaximum(Calendar.YEAR) ||
-                    year < c.getActualMinimum(Calendar.YEAR)) {
+            try {
+                zdt = ZonedDateTime
+                    .of(year, month, day, 0, 0, 0, 0, ZoneId.of("GMT"));
+                denyAfterDate = zdt.toInstant();
+            } catch (DateTimeException dte) {
                 throw new IllegalArgumentException(
-                        "Invalid year given in constraint: " + year);
-            }
-            if ((month - 1) > c.getActualMaximum(Calendar.MONTH) ||
-                    (month - 1) < c.getActualMinimum(Calendar.MONTH)) {
-                throw new IllegalArgumentException(
-                        "Invalid month given in constraint: " + month);
-            }
-            if (day > c.getActualMaximum(Calendar.DAY_OF_MONTH) ||
-                    day < c.getActualMinimum(Calendar.DAY_OF_MONTH)) {
-                throw new IllegalArgumentException(
-                        "Invalid Day of Month given in constraint: " + day);
+                    "Invalid denyAfter date", dte);
             }
 
-            denyAfterDate = c.getTime();
             if (debug != null) {
                 debug.println("DenyAfterConstraint date set to: " +
-                        denyAfterDate);
+                        zdt.toLocalDate());
             }
         }
 
@@ -740,23 +731,22 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
         @Override
         public void permits(ConstraintsParameters cp)
                 throws CertPathValidatorException {
-            Date currentDate;
-            String errmsg;
+            Instant currentDate;
 
             if (cp.getDate() != null) {
-                currentDate = cp.getDate();
+                currentDate = cp.getDate().toInstant();
             } else {
-                currentDate = new Date();
+                currentDate = Instant.now();
             }
 
-            if (!denyAfterDate.after(currentDate)) {
+            if (!denyAfterDate.isAfter(currentDate)) {
                 if (next(cp)) {
                     return;
                 }
                 throw new CertPathValidatorException(
                         "denyAfter constraint check failed: " + algorithm +
                         " used with Constraint date: " +
-                        denyAfterDate + "; params date: " +
+                        zdt.toLocalDate() + "; params date: " +
                         currentDate + cp.extendedExceptionMsg(),
                         null, null, -1, BasicReason.ALGORITHM_CONSTRAINED);
             }
@@ -775,7 +765,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
                 debug.println("DenyAfterConstraints.permits(): " + algorithm);
             }
 
-            return denyAfterDate.after(new Date());
+            return denyAfterDate.isAfter(Instant.now());
         }
     }
 

--- a/test/jdk/java/security/SignedJar/CustomClassLoader.java
+++ b/test/jdk/java/security/SignedJar/CustomClassLoader.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class CustomClassLoader extends ClassLoader {
+
+    public CustomClassLoader(ClassLoader parent) {
+        super(parent);
+    }
+
+    @Override
+    public Class<?> findClass(String name) throws ClassNotFoundException {
+        try (InputStream is = getClass().getClassLoader()
+                .getResourceAsStream(name + ".class")) {
+            byte[] buf = is.readAllBytes();
+            return defineClass(name, buf, 0, buf.length);
+        } catch (IOException e) {
+            throw new ClassNotFoundException(e.getMessage());
+        }
+    }
+}

--- a/test/jdk/java/security/SignedJar/SignedJarWithCustomClassLoader.java
+++ b/test/jdk/java/security/SignedJar/SignedJarWithCustomClassLoader.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8280890
+ * @library /test/lib
+ * @build SignedJarWithCustomClassLoader CustomClassLoader
+ * @run main/othervm SignedJarWithCustomClassLoader
+ * @summary Make sure java.system.class.loader property can be used when custom
+ *     class loader is inside signed jar
+ */
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import jdk.test.lib.SecurityTools;
+import jdk.test.lib.compiler.InMemoryJavaCompiler;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.util.JarUtils;
+
+public class SignedJarWithCustomClassLoader {
+
+    public static void main(String[] args) throws Exception {
+
+        // compile the Main program
+        String main = "public class Main {\n" +
+                      "    public static void main(String[] args) {}\n" +
+                      "}\n";
+        String testClasses = System.getProperty("test.classes", "");
+        ClassFileInstaller.writeClassToDisk("Main",
+             InMemoryJavaCompiler.compile("Main", main),
+             testClasses);
+
+        // create the jar file
+        Path classes = Paths.get(testClasses);
+        JarUtils.createJarFile(Paths.get("test.jar"), classes,
+            classes.resolve("CustomClassLoader.class"),
+            classes.resolve("Main.class"));
+
+        // create signer's keypair
+        SecurityTools.keytool("-genkeypair -keyalg RSA -keystore ks " +
+                              "-storepass changeit -dname CN=test -alias test")
+                     .shouldHaveExitValue(0);
+
+        // sign jar
+        SecurityTools.jarsigner("-keystore ks -storepass changeit " +
+                                "-signedjar signed.jar test.jar test")
+                     .shouldHaveExitValue(0);
+
+        // run app with system class loader set to custom classloader
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-cp", "signed.jar",
+            "-Djava.system.class.loader=CustomClassLoader", "Main");
+        ProcessTools.executeProcess(pb)
+                    .shouldHaveExitValue(0);
+
+        // sign jar again, but this time with SHA-1 which is disabled
+        SecurityTools.jarsigner("-keystore ks -storepass changeit " +
+                                "-digestalg SHA-1 -sigalg SHA1withRSA " +
+                                "-signedjar signed.jar test.jar test")
+                     .shouldHaveExitValue(0);
+
+        // run app again, should still succeed even though SHA-1 is disabled
+        pb = ProcessTools.createJavaProcessBuilder(
+            "-cp", "signed.jar",
+            "-Djava.system.class.loader=CustomClassLoader", "Main");
+        ProcessTools.executeProcess(pb)
+                    .shouldHaveExitValue(0);
+    }
+}


### PR DESCRIPTION
Please review this almost clean backport (modulo copyright header in `DisabledAlgorithmConstraints`) in the product code. The test needed some changes to make it work (removal of text block syntax, `ClassFileInstaller` import change).

It fixes a regression introduced with [JDK-8269039: Disable SHA-1 Signed JARs](https://bugs.openjdk.org/browse/JDK-8269039) which was included in `11.0.17` (note that `11.0.16` is not affected as  JDK-8269039 is not there). This should be low-risk as it mainly removes use of `java.util.Calendar` API usage in `DisabledAlgorithmConstraints` which can cause issues with applications that contain `CalendarDataProvider`s in signed jars. See [JDK-8297684](https://bugs.openjdk.org/browse/JDK-8297684) for details.

Proposing as critical fix so that we don't have another release with that regression.

Regression test fails prior and passes after the product fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280890](https://bugs.openjdk.org/browse/JDK-8280890): Cannot use '-Djava.system.class.loader' with class loader in signed JAR


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.org/jdk11u pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/65.diff">https://git.openjdk.org/jdk11u/pull/65.diff</a>

</details>
