### PR TITLE
 Backport 8216995: Clean up JFR command line processing

### DIFF
--- a/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
+++ b/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,27 +44,16 @@
 #include "logging/logStream.hpp"
 #include "memory/resourceArea.inline.hpp"
 #include "runtime/handles.inline.hpp"
-#include "runtime/flags/jvmFlag.hpp"
-#include "runtime/globals.hpp"
+#include "runtime/globals_extension.hpp"
 #include "utilities/growableArray.hpp"
 #ifdef ASSERT
 #include "prims/jvmtiEnvBase.hpp"
 #endif
 
-static bool is_disabled_on_command_line() {
-  static const size_t length = strlen("FlightRecorder");
-  static JVMFlag* const flight_recorder_flag = JVMFlag::find_flag("FlightRecorder", length);
-  assert(flight_recorder_flag != NULL, "invariant");
-  return flight_recorder_flag->is_command_line() ? !FlightRecorder : false;
-}
-
 bool JfrRecorder::is_disabled() {
-  return is_disabled_on_command_line();
-}
-
-static bool set_flight_recorder_flag(bool flag_value) {
-  JVMFlag::boolAtPut((char*)"FlightRecorder", &flag_value, JVMFlag::MANAGEMENT);
-  return FlightRecorder;
+  // True if -XX:-FlightRecorder has been explicitly set on the
+  // command line
+  return FLAG_IS_CMDLINE(FlightRecorder) ? !FlightRecorder : false;
 }
 
 static bool _enabled = false;
@@ -72,8 +61,10 @@ static bool _enabled = false;
 static bool enable() {
   assert(!_enabled, "invariant");
   if (!FlightRecorder) {
-    _enabled = set_flight_recorder_flag(true);
+    FLAG_SET_MGMT(bool, FlightRecorder, true);
   }
+  _enabled = FlightRecorder;
+  assert(_enabled, "invariant");
   return _enabled;
 }
 

--- a/src/hotspot/share/runtime/globals_extension.hpp
+++ b/src/hotspot/share/runtime/globals_extension.hpp
@@ -306,6 +306,8 @@ typedef enum {
 #define FLAG_SET_CMDLINE(type, name, value) (JVMFlagEx::setOnCmdLine(FLAG_MEMBER_WITH_TYPE(name, type)), \
                                              JVMFlagEx::type##AtPut(FLAG_MEMBER_WITH_TYPE(name, type), (type)(value), JVMFlag::COMMAND_LINE))
 #define FLAG_SET_ERGO(type, name, value)    (JVMFlagEx::type##AtPut(FLAG_MEMBER_WITH_TYPE(name, type), (type)(value), JVMFlag::ERGONOMIC))
+#define FLAG_SET_MGMT(type, name, value)    (JVMFlagEx::type##AtPut(FLAG_MEMBER_WITH_TYPE(name, type), (type)(value), JVMFlag::MANAGEMENT))
+
 #define FLAG_SET_ERGO_IF_DEFAULT(type, name, value) \
   do {                                              \
     if (FLAG_IS_DEFAULT(name)) {                    \


### PR DESCRIPTION
Original JBS Issue: [https://bugs.openjdk.org/browse/JDK-8216995](url)
Original Commit : [http://hg.openjdk.java.net/jdk/jdk/rev/65a1d49d1718](url)

- [x] Backport

### **Description:** 
This PR contains the backport coed for Cleanup JFR command processing. 
JfrRecorder::is_disabled is called early during bootstrap and uses JVMFlag::find_flag directly to check whether the -XX:-FlightRecorder has been set on the command line. Using the FLAG_IS_CMDLINE macro from global_extensions have the same effect cleans it up and might avoid a linear scan.

Also clean up enable () to use a macro to set the FlightRecorder value.

### **Differences from Original Commit:** 
- In the enable () method - Line 63: There is an additional validation check for the flight recorder value. If the FlightRecorder value is already set to true, then the FLAG_SET_MGMT(bool, FlightRecorder, true); is skipped. 

### **Testing**:
- [x] All existing test pass locally
- [x] PR build is succeeded

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.org/jdk11u pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/66.diff">https://git.openjdk.org/jdk11u/pull/66.diff</a>

</details>
