### PR TITLE
JDK-8302000: A subtle race condition during jdk11u build

### DIFF
--- a/make/gensrc/GensrcBuffer.gmk
+++ b/make/gensrc/GensrcBuffer.gmk
@@ -230,7 +230,8 @@ define SetupGenBuffer
   endif
 
   $$($1_DST): $$($1_DEP) $(GENSRC_BUFFER_DST)/_the.buffer.dir
-	$(TOOL_SPP) < $$($1_SRC) > $$($1_OUT).tmp \
+	$(RM) $$($1_OUT).tmp
+	$(TOOL_SPP) -i$$($1_SRC) -o$$($1_OUT).tmp \
 	    -K$$($1_type) \
 	    -K$$($1_category) \
 	    -K$$($1_streams) \
@@ -260,12 +261,12 @@ define SetupGenBuffer
         ifeq ($$($1_BIN), 1)
 	  $(SED) -e '/#BIN/,$$$$d' < $$($1_OUT) > $$($1_DST).tmp
 	  $(RM) $$($1_OUT)
-	  $$($1_char_CMD) < $$($1_SRC_BIN) >> $$($1_DST).tmp
-	  $$($1_short_CMD) < $$($1_SRC_BIN) >> $$($1_DST).tmp
-	  $$($1_int_CMD) < $$($1_SRC_BIN) >> $$($1_DST).tmp
-	  $$($1_long_CMD) < $$($1_SRC_BIN) >> $$($1_DST).tmp
-	  $$($1_float_CMD) < $$($1_SRC_BIN) >> $$($1_DST).tmp
-	  $$($1_double_CMD) < $$($1_SRC_BIN) >> $$($1_DST).tmp
+	  $$($1_char_CMD) -i$$($1_SRC_BIN) -o$$($1_DST).tmp
+	  $$($1_short_CMD) -i$$($1_SRC_BIN) -o$$($1_DST).tmp
+	  $$($1_int_CMD) -i$$($1_SRC_BIN) -o$$($1_DST).tmp
+	  $$($1_long_CMD) -i$$($1_SRC_BIN) -o$$($1_DST).tmp
+	  $$($1_float_CMD) -i$$($1_SRC_BIN) -o$$($1_DST).tmp
+	  $$($1_double_CMD) -i$$($1_SRC_BIN) -o$$($1_DST).tmp
 	  $(PRINTF) "}\n" >> $$($1_DST).tmp
 	  mv $$($1_DST).tmp $$($1_DST)
         endif

--- a/make/gensrc/GensrcCharsetCoder.gmk
+++ b/make/gensrc/GensrcCharsetCoder.gmk
@@ -37,7 +37,7 @@ $(GENSRC_CHARSETCODER_DST)/CharsetDecoder.java: $(GENSRC_CHARSETCODER_TEMPLATE)
 	$(MKDIR) -p $(@D)
 	-$(RM) $@.tmp
 	$(call ExecuteWithLog, $(SUPPORT_OUTPUTDIR)/gensrc/java.base/_charset_decoder, \
-		$(TOOL_SPP) < $< >$@.tmp \
+		$(TOOL_SPP) -i$< -o$@.tmp \
 	    -Kdecoder \
 	    -DA='A' \
 	    -Da='a' \
@@ -73,7 +73,7 @@ $(GENSRC_CHARSETCODER_DST)/CharsetEncoder.java: $(GENSRC_CHARSETCODER_TEMPLATE)
 	$(MKDIR) -p $(@D)
 	-$(RM) $@.tmp
 	$(call ExecuteWithLog, $(SUPPORT_OUTPUTDIR)/gensrc/java.base/_charset_encoder, \
-		$(TOOL_SPP) < $< >$@.tmp \
+		$(TOOL_SPP) -i$< -o$@.tmp \
 	    -Kencoder \
 	    -DA='An' \
 	    -Da='an' \

--- a/make/gensrc/GensrcVarHandles.gmk
+++ b/make/gensrc/GensrcVarHandles.gmk
@@ -60,7 +60,7 @@ define GenerateVarHandle
         endif
 	$$(call MakeDir, $$(@D))
 	$(TOOL_SPP) -nel -K$$($1_type) -Dtype=$$($1_type) -DType=$$($1_Type) \
-	    $$($1_ARGS) < $$< > $$@
+	    $$($1_ARGS) -i$$< -o$$@
 
   GENSRC_VARHANDLES += $$($1_FILENAME)
 endef
@@ -150,7 +150,7 @@ define GenerateVarHandleByteArray
 	$(TOOL_SPP) -nel -K$$($1_type) \
 	    -Dtype=$$($1_type) -DType=$$($1_Type) -DBoxType=$$($1_BoxType) \
 	    -DrawType=$$($1_rawType) -DRawType=$$($1_RawType) -DRawBoxType=$$($1_RawBoxType) \
-	    $$($1_ARGS) < $$< > $$@
+	    $$($1_ARGS) -i$$< -o$$@
 
   GENSRC_VARHANDLES += $$($1_FILENAME)
 endef

--- a/make/jdk/src/classes/build/tools/spp/Spp.java
+++ b/make/jdk/src/classes/build/tools/spp/Spp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package build.tools.spp;
 
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.util.*;
 import java.util.regex.*;
 
@@ -32,7 +34,8 @@ import java.util.regex.*;
  * Spp: A simple regex-based stream preprocessor based on Mark Reinhold's
  *      sed-based spp.sh
  *
- * Usage: java build.tools.spp.Spp [-be] [-nel] [-Kkey] -Dvar=value ... <in >out
+ * Usage:
+ * java build.tools.spp.Spp [-be] [-nel] [-Kkey] -Dvar=value ... -iin -oout
  *
  * If -nel is declared then empty lines will not be substituted for lines of
  * text in the template that do not appear in the output.
@@ -69,6 +72,8 @@ public class Spp {
         Set<String> keys = new HashSet<>();
         boolean be = false;
         boolean el = true;
+        String inputFile = null;
+        String outputFile = null;
 
         for (String arg:args) {
             if (arg.startsWith("-D")) {
@@ -76,6 +81,10 @@ public class Spp {
                 vars.put(arg.substring(2, i),arg.substring(i+1));
             } else if (arg.startsWith("-K")) {
                 keys.add(arg.substring(2));
+            } else if (arg.startsWith("-i")) {
+                inputFile = arg.substring(2);
+            } else if (arg.startsWith("-o")) {
+                outputFile = arg.substring(2);
             } else if ("-be".equals(arg)) {
                 be = true;
             } else if ("-nel".equals(arg)) {
@@ -87,17 +96,17 @@ public class Spp {
         }
 
         StringBuffer out = new StringBuffer();
-        new Spp().spp(new Scanner(System.in),
+        new Spp().spp(new Scanner(new FileInputStream(inputFile)),
                       out, "",
                       keys, vars, be, el,
                       false);
-        System.out.print(out.toString());
+        new FileOutputStream(outputFile, true).write(out.toString().getBytes());
     }
 
     static final String LNSEP = System.getProperty("line.separator");
     static final String KEY = "([a-zA-Z0-9]+)";
     static final String VAR = "([a-zA-Z0-9_\\-]+)";
-    static final String TEXT = "([a-zA-Z0-9&;,.<>/#() \\?\\[\\]\\$]+)"; // $ -- hack embedded $var$
+    static final String TEXT = "([\\p{Print}&&[^{#:}]]+)";
 
     static final int GN_NOT = 1;
     static final int GN_KEY = 2;
@@ -130,6 +139,10 @@ public class Spp {
                         repl = vardef2.replaceFirst(vars.get(vardef2.group(1)));
                     }
                 }
+            }
+            if (repl == null) {
+                System.err.println("Error: undefined variable in line " + ln);
+                System.exit(-1);
             }
             vardef.appendReplacement(buf, repl);
         }

--- a/test/hotspot/jtreg/compiler/unsafe/generate-unsafe-access-tests.sh
+++ b/test/hotspot/jtreg/compiler/unsafe/generate-unsafe-access-tests.sh
@@ -124,7 +124,7 @@ function generate {
 
       echo $args
       java $SPP -nel -K$Qualifier -Dpackage=$package -DQualifier=$Qualifier -Dmodule=$module \
-          $args < X-UnsafeAccessTest.java.template > ${Qualifier}UnsafeAccessTest${Type}.java
+          $args -iX-UnsafeAccessTest.java.template -o${Qualifier}UnsafeAccessTest${Type}.java
     done
 }
 

--- a/test/jdk/java/lang/invoke/VarHandles/generate-vh-tests.sh
+++ b/test/jdk/java/lang/invoke/VarHandles/generate-vh-tests.sh
@@ -82,9 +82,9 @@ do
   args="$args -Dvalue1=$value1 -Dvalue2=$value2 -Dvalue3=$value3 -Dwrong_primitive_type=$wrong_primitive_type"
 
   echo $args
-  java $SPP -nel $args < X-VarHandleTestAccess.java.template > VarHandleTestAccess${Type}.java
-  java $SPP -nel $args < X-VarHandleTestMethodHandleAccess.java.template > VarHandleTestMethodHandleAccess${Type}.java
-  java $SPP -nel $args < X-VarHandleTestMethodType.java.template > VarHandleTestMethodType${Type}.java
+  java $SPP -nel $args -iX-VarHandleTestAccess.java.template -oVarHandleTestAccess${Type}.java
+  java $SPP -nel $args -iX-VarHandleTestMethodHandleAccess.java.template -oVarHandleTestMethodHandleAccess${Type}.java
+  java $SPP -nel $args -iX-VarHandleTestMethodType.java.template -oVarHandleTestMethodType${Type}.java
 done
 
 for type in short char int long float double
@@ -161,7 +161,7 @@ do
   args="$args -Dvalue1=$value1 -Dvalue2=$value2 -Dvalue3=$value3"
 
   echo $args
-  java $SPP -nel $args < X-VarHandleTestByteArrayView.java.template > VarHandleTestByteArrayAs${Type}.java
+  java $SPP -nel $args -iX-VarHandleTestByteArrayView.java.template -oVarHandleTestByteArrayAs${Type}.java
 done
 
 rm -fr build

--- a/test/jdk/java/nio/Buffer/genBasic.sh
+++ b/test/jdk/java/nio/Buffer/genBasic.sh
@@ -26,7 +26,7 @@
 javac -d . ../../../../make/src/classes/build/tools/spp/Spp.java
 
 gen() {
-    java build.tools.spp.Spp -K$1 -Dtype=$1 -DType=$2 -DFulltype=$3 <Basic-X.java.template >Basic$2.java
+    java build.tools.spp.Spp -K$1 -Dtype=$1 -DType=$2 -DFulltype=$3 -iBasic-X.java.template -oBasic$2.java
 }
 
 gen byte Byte Byte

--- a/test/jdk/java/nio/Buffer/genCopyDirectMemory.sh
+++ b/test/jdk/java/nio/Buffer/genCopyDirectMemory.sh
@@ -26,7 +26,7 @@
 javac -d . ../../../../make/src/classes/build/tools/spp/Spp.java > Spp.java
 
 gen() {
-    java  build.tools.spp.Spp -K$1 -Dtype=$1 -DType=$2 -DFulltype=$3<CopyDirect-X-Memory.java.template >CopyDirect$2Memory.java
+    java  build.tools.spp.Spp -K$1 -Dtype=$1 -DType=$2 -DFulltype=$3 -iCopyDirect-X-Memory.java.template -oCopyDirect$2Memory.java
 }
 
 gen byte Byte Byte

--- a/test/jdk/java/nio/Buffer/genOrder.sh
+++ b/test/jdk/java/nio/Buffer/genOrder.sh
@@ -26,7 +26,7 @@
 javac -d . ../../../../make/src/classes/build/tools/spp/Spp.java > Spp.java
 
 gen() {
-    java  build.tools.spp.Spp -K$1 -Dtype=$1 -DType=$2 -DFulltype=$3<Order-X.java.template >Order$2.java
+    java  build.tools.spp.Spp -K$1 -Dtype=$1 -DType=$2 -DFulltype=$3 -iOrder-X.java.template -oOrder$2.java
 }
 
 gen char Char Character

--- a/test/jdk/java/util/Formatter/genBasic.sh
+++ b/test/jdk/java/util/Formatter/genBasic.sh
@@ -27,10 +27,10 @@ javac -d . ../../../../../make/jdk/src/classes/build/tools/spp/Spp.java
 
 gen() {
 #  if [ $3 = "true" ]
-#  then $SPP -K$1 -Dtype=$1 -DType=$2 -Kprim<Basic-X.java.template >Basic$2.java
-#  else $SPP -K$1 -Dtype=$1 -DType=$2 -K$3 <Basic-X.java.template >Basic$2.java
+#  then $SPP -K$1 -Dtype=$1 -DType=$2 -Kprim -iBasic-X.java.template -oBasic$2.java
+#  else $SPP -K$1 -Dtype=$1 -DType=$2 -K$3 -iBasic-X.java.template -oBasic$2.java
 #  fi
-    java build.tools.spp.Spp -K$1 -Dtype=$1 -DType=$2 -K$3 -K$4 -K$5 -K$6 <Basic-X.java.template >Basic$2.java
+    java build.tools.spp.Spp -K$1 -Dtype=$1 -DType=$2 -K$3 -K$4 -K$5 -K$6 -iBasic-X.java.template -oBasic$2.java
 }
 
 gen boolean Boolean       prim  ""  ""   ""


### PR DESCRIPTION
This is primarily a back-port of various fixes made in the development branch, please refer to the JBS issue for details.

Spp.java:  no longer uses stdin/stdout for IO. Now uses File IO, which is safer to use with makefile logging, whereby the use of macros can cause undesired and obscure side-effects with source generation using Spp.java.

Other changes are to the make logic itself to use the new -i and -o options.

[![OpenJDK GHA Sanity Checks](https://github.com/kusrinivasan/jdk11u/actions/workflows/main.yml/badge.svg?branch=topic-jdk-8302000)](https://github.com/kusrinivasan/jdk11u/actions/workflows/main.yml)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302000](https://bugs.openjdk.org/browse/JDK-8302000): A subtle race condition during jdk11u build


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/jdk11u pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/68.diff">https://git.openjdk.org/jdk11u/pull/68.diff</a>

</details>
