### PR TITLE
8304389: [11u] Crash on Windows in C2 compiled code after 8248238 and 8218431

### DIFF
--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -103,8 +103,10 @@ ifeq ($(call check-jvm-feature, compiler2), true)
       ADLCFLAGS += -DR18_RESERVED
     endif
   else ifeq ($(OPENJDK_TARGET_OS), windows)
-    ifeq ($(HOTSPOT_TARGET_CPU_ARCH), aarch64)
+    ifeq ($(call isTargetCpuBits, 64), true)
       ADLCFLAGS += -D_WIN64=1
+    endif
+    ifeq ($(HOTSPOT_TARGET_CPU_ARCH), aarch64)
       ADLCFLAGS += -DR18_RESERVED=1
     endif
   endif

--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -103,10 +103,8 @@ ifeq ($(call check-jvm-feature, compiler2), true)
       ADLCFLAGS += -DR18_RESERVED
     endif
   else ifeq ($(OPENJDK_TARGET_OS), windows)
-    ifeq ($(call isTargetCpuBits, 64), true)
-      ADLCFLAGS += -D_WIN64=1
-    endif
     ifeq ($(HOTSPOT_TARGET_CPU_ARCH), aarch64)
+      ADLCFLAGS += -D_WIN64=1
       ADLCFLAGS += -DR18_RESERVED=1
     endif
   endif

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -87,7 +87,7 @@ reg_def RBP  (NS, SOE, Op_RegI,  5, rbp->as_VMReg());
 reg_def RBP_H(NS, SOE, Op_RegI,  5, rbp->as_VMReg()->next());
 
 // #ifdef _WIN64  There is a problem in 11u with this, see JDK-8304389.
-#ifdef WRONG
+#ifdef DISABLED
 
 reg_def RSI  (SOC, SOE, Op_RegI,  6, rsi->as_VMReg());
 reg_def RSI_H(SOC, SOE, Op_RegI,  6, rsi->as_VMReg()->next());

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -86,7 +86,8 @@ reg_def RSP_H(NS,  NS,  Op_RegI,  4, rsp->as_VMReg()->next());
 reg_def RBP  (NS, SOE, Op_RegI,  5, rbp->as_VMReg());
 reg_def RBP_H(NS, SOE, Op_RegI,  5, rbp->as_VMReg()->next());
 
-#ifdef _WIN64
+// #ifdef _WIN64  There is a problem in 11u with this, see JDK-8304389.
+#ifdef WRONG
 
 reg_def RSI  (SOC, SOE, Op_RegI,  6, rsi->as_VMReg());
 reg_def RSI_H(SOC, SOE, Op_RegI,  6, rsi->as_VMReg()->next());


### PR DESCRIPTION
… 8218431

A required fix to avoid regression in 11.0.19. See JBS issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304389](https://bugs.openjdk.org/browse/JDK-8304389): [11u] Crash on Windows in C2 compiled code after 8248238 and 8218431


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - Committer) ⚠️ Review applies to [fc3c38f8](https://git.openjdk.org/jdk11u/pull/70/files/fc3c38f8c90ebdcd1f5e72dd09f2ae84fd70f050)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u.git pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.org/jdk11u.git pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/70.diff">https://git.openjdk.org/jdk11u/pull/70.diff</a>

</details>
