### PR TITLE
8309476: [11u] tools/jmod/hashes/HashesOrderTest.java fails intermittently

### DIFF
--- a/test/jdk/tools/jmod/hashes/HashesOrderTest.java
+++ b/test/jdk/tools/jmod/hashes/HashesOrderTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8240903
+ * @key intermittent
  * @summary Test consistency of moduleHashes attribute between builds
  * @library /test/lib
  * @run testng HashesOrderTest


### PR DESCRIPTION
The test 'tools/jmod/hashes/HashesOrderTest.java', introduced by [JDK-8240903](https://bugs.openjdk.org/browse/JDK-8240903), was backported to 11.0.17 via [JDK-8287791](https://bugs.openjdk.org/browse/JDK-8287791). However, JDK11 doesn't support specifying "--date". This appears to be needed in order to make the test reliable. The hashes of two jmod files may differ if the timestamp differs.

The "--date" option was implemented with [JDK-8276766](https://bugs.openjdk.org/browse/JDK-8276766) for JDK 19 and has only been backported to JDK 17. It is a feature that comes with a CSR and might not be worthwile doing for the JDK11 updates release. For now, the test should be marked as @intermittent until [JDK-8276766](https://bugs.openjdk.org/browse/JDK-8276766) is brought to JDK11 updates.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309476](https://bugs.openjdk.org/browse/JDK-8309476): [11u] tools/jmod/hashes/HashesOrderTest.java fails intermittently (**Bug** - `"4"`)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u.git pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.org/jdk11u.git pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/72.diff">https://git.openjdk.org/jdk11u/pull/72.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u/pull/72#issuecomment-1579935760)