### PR TITLE
Backport 924720f6fc80

### DIFF
--- a/test/hotspot/jtreg/sanity/MismatchedWhiteBox/WhiteBox.java
+++ b/test/hotspot/jtreg/sanity/MismatchedWhiteBox/WhiteBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,15 @@
 package sun.hotspot;
 
 public class WhiteBox {
+    @SuppressWarnings("serial")
+    public static class WhiteBoxPermission extends java.security.BasicPermission {
+        // ClassFileInstaller is hard-coded to copy WhiteBox$WhiteBoxPermission, so let's
+        // make a fake one here as well.
+        public WhiteBoxPermission(String s) {
+            super(s);
+        }
+    }
+
     private static native void registerNatives();
     static { registerNatives(); }
     public native int notExistedMethod();


### PR DESCRIPTION
8236045: [TESTBUG] MismatchedWhiteBox test fails with missing WhiteBox$WhiteBoxPermission.class

Reviewed-by: Yi Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u.git pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.org/jdk11u.git pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/75.diff">https://git.openjdk.org/jdk11u/pull/75.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u/pull/75#issuecomment-1597110152)