### PR TITLE
8293107: GHA: Bump to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -29,14 +29,22 @@ on:
   workflow_call:
     inputs:
       gcc-major-version:
+        required: true
+        type: string
+      extra-conf-options:
         required: false
         type: string
-        default: '10'
+      configure-arguments:
+        required: false
+        type: string
+      make-arguments:
+        required: false
+        type: string
 
 jobs:
   build-cross-compile:
     name: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -110,7 +118,7 @@ jobs:
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
           --resolve-deps
-          buster
+          bullseye
           sysroot
           https://httpredir.debian.org/debian/
         if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
@@ -135,12 +143,16 @@ jobs:
           --openjdk-target=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}
           --with-sysroot=sysroot
           --with-build-jdk=${{ steps.buildjdk.outputs.jdk-path }}
-          CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-gcc-10
-          CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-g++-10
+          CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-gcc-${{ inputs.gcc-major-version }}
+          CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-g++-${{ inputs.gcc-major-version }}
+          ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
 
       - name: 'Build'
         id: build
         uses: ./.github/actions/do-build
         with:
-          make-target: 'hotspot'
+          make-target: 'hotspot ${{ inputs.make-arguments }}'
           platform: linux-${{ matrix.target-cpu }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -42,20 +42,30 @@ on:
         required: false
         type: string
         default: '[ "debug", "release" ]'
-      apt-gcc-version:
+      gcc-major-version:
         required: true
         type: string
+      gcc-package-suffix:
+        required: false
+        type: string
+        default: ''
       apt-architecture:
         required: false
         type: string
       apt-extra-packages:
         required: false
         type: string
+      configure-arguments:
+        required: false
+        type: string
+      make-arguments:
+        required: false
+        type: string
 
 jobs:
   build-linux:
     name: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -97,8 +107,8 @@ jobs:
           fi
           sudo apt-get update
           sudo apt-get install --only-upgrade apt
-          sudo apt-get install gcc-${{ inputs.apt-gcc-version }} g++-${{ inputs.apt-gcc-version }} libxrandr-dev${{ steps.arch.outputs.suffix }} libxtst-dev${{ steps.arch.outputs.suffix }} libcups2-dev${{ steps.arch.outputs.suffix }} libasound2-dev${{ steps.arch.outputs.suffix }} ${{ inputs.apt-extra-packages }}
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+          sudo apt-get install gcc-${{ inputs.gcc-major-version }}${{ inputs.gcc-package-suffix }} g++-${{ inputs.gcc-major-version }}${{ inputs.gcc-package-suffix }} libxrandr-dev${{ steps.arch.outputs.suffix }} libxtst-dev${{ steps.arch.outputs.suffix }} libcups2-dev${{ steps.arch.outputs.suffix }} libasound2-dev${{ steps.arch.outputs.suffix }} ${{ inputs.apt-extra-packages }}
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc-major-version }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc-major-version }}
 
       - name: 'Configure'
         run: >
@@ -110,13 +120,16 @@ jobs:
           --with-jtreg=${{ steps.jtreg.outputs.path }}
           --enable-jtreg-failure-handler
           --with-zlib=system
-          ${{ inputs.extra-conf-options }}
+          ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
 
       - name: 'Build'
         id: build
         uses: ./.github/actions/do-build
         with:
-          make-target: '${{ inputs.make-target }}'
+          make-target: '${{ inputs.make-target }} ${{ inputs.make-arguments }}'
           platform: ${{ inputs.platform }}
           debug-suffix: '${{ matrix.suffix }}'
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -45,6 +45,12 @@ on:
       xcode-toolset-version:
         required: true
         type: string
+      configure-arguments:
+        required: false
+        type: string
+      make-arguments:
+        required: false
+        type: string
 
 jobs:
   build-macos:
@@ -92,13 +98,16 @@ jobs:
           --with-jtreg=${{ steps.jtreg.outputs.path }}
           --enable-jtreg-failure-handler
           --with-zlib=system
-          ${{ inputs.extra-conf-options }}
+          ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
 
       - name: 'Build'
         id: build
         uses: ./.github/actions/do-build
         with:
-          make-target: '${{ inputs.make-target }}'
+          make-target: '${{ inputs.make-target }} ${{ inputs.make-arguments }}'
           platform: ${{ inputs.platform }}
           debug-suffix: '${{ matrix.suffix }}'
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -48,6 +48,12 @@ on:
       msvc-toolset-architecture:
         required: true
         type: string
+      configure-arguments:
+        required: false
+        type: string
+      make-arguments:
+        required: false
+        type: string
 
 env:
   # These are needed to make the MSYS2 bash work properly
@@ -119,7 +125,10 @@ jobs:
           --with-jtreg=${{ steps.jtreg.outputs.path }}
           --enable-jtreg-failure-handler
           --with-msvc-toolset-version=${{ inputs.msvc-toolset-version }}
-          ${{ inputs.extra-conf-options }}
+          ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
         env:
           # We need a minimal PATH on Windows
           # Set PATH to "", so just GITHUB_PATH is included
@@ -129,7 +138,7 @@ jobs:
         id: build
         uses: ./.github/actions/do-build
         with:
-          make-target: '${{ inputs.make-target }}'
+          make-target: '${{ inputs.make-target }} ${{ inputs.make-arguments }}'
           platform: ${{ inputs.platform }}
           debug-suffix: '${{ matrix.suffix }}'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,12 @@ on:
         description: 'Platform(s) to execute on (comma separated, e.g. "linux-x64, macos, aarch64")'
         required: true
         default: 'linux-x64, linux-x86, linux-x64-variants, linux-cross-compile, macos-x64, macos-aarch64, windows-x64, windows-aarch64'
+      configure-arguments:
+        description: 'Additional configure arguments'
+        required: false
+      make-arguments:
+        description: 'Additional make arguments'
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -49,7 +55,7 @@ jobs:
 
   select:
     name: 'Select platforms'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       linux-x64: ${{ steps.include.outputs.linux-x64 }}
       linux-x86: ${{ steps.include.outputs.linux-x86 }}
@@ -121,7 +127,9 @@ jobs:
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x64
-      apt-gcc-version: '10'
+      gcc-major-version: '10'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     # The linux-x64 jdk bundle is used as buildjdk for the cross-compile job
     if: needs.select.outputs.linux-x64 == 'true' || needs.select.outputs.linux-cross-compile == 'true'
 
@@ -131,12 +139,15 @@ jobs:
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x86
-      apt-gcc-version: '10-multilib'
+      gcc-major-version: '10'
+      gcc-package-suffix: '-multilib'
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
       apt-extra-packages: 'libfreetype6-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386'
       extra-conf-options: '--with-target-bits=32'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x86 == 'true'
 
   build-linux-x64-hs-nopch:
@@ -147,8 +158,10 @@ jobs:
       platform: linux-x64
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10'
+      gcc-major-version: '10'
       extra-conf-options: '--disable-precompiled-headers'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x64-variants == 'true'
 
   build-linux-x64-hs-zero:
@@ -159,8 +172,10 @@ jobs:
       platform: linux-x64
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10'
+      gcc-major-version: '10'
       extra-conf-options: '--with-jvm-variants=zero --disable-precompiled-headers'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x64-variants == 'true'
 
   build-linux-x64-hs-minimal:
@@ -171,8 +186,10 @@ jobs:
       platform: linux-x64
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10'
+      gcc-major-version: '10'
       extra-conf-options: '--with-jvm-variants=minimal --disable-precompiled-headers'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x64-variants == 'true'
 
   build-linux-x64-hs-optimized:
@@ -184,8 +201,10 @@ jobs:
       make-target: 'hotspot'
       # Technically this is not the "debug" level, but we can't inject a new matrix state for just this job
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10'
+      gcc-major-version: '10'
       extra-conf-options: '--with-debug-level=optimized --disable-precompiled-headers'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x64-variants == 'true'
 
   build-linux-cross-compile:
@@ -194,6 +213,10 @@ jobs:
       - select
       - build-linux-x64
     uses: ./.github/workflows/build-cross-compile.yml
+    with:
+      gcc-major-version: '10'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-cross-compile == 'true'
 
   build-macos-x64:
@@ -203,6 +226,8 @@ jobs:
     with:
       platform: macos-x64
       xcode-toolset-version: '11.7'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.macos-x64 == 'true'
 
   build-macos-aarch64:
@@ -213,6 +238,8 @@ jobs:
       platform: macos-aarch64
       xcode-toolset-version: '12.4'
       extra-conf-options: '--openjdk-target=aarch64-apple-darwin'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.macos-aarch64 == 'true'
 
   build-windows-x64:
@@ -223,6 +250,8 @@ jobs:
       platform: windows-x64
       msvc-toolset-version: '14.29'
       msvc-toolset-architecture: 'x86.x64'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.windows-x64 == 'true'
 
   build-windows-aarch64:
@@ -235,6 +264,8 @@ jobs:
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
       extra-conf-options: '--openjdk-target=aarch64-unknown-cygwin'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.windows-aarch64 == 'true'
 
   ###
@@ -249,7 +280,7 @@ jobs:
     with:
       platform: linux-x64
       bootjdk-platform: linux-x64
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
 
   test-linux-x86:
     name: linux-x86
@@ -259,7 +290,7 @@ jobs:
     with:
       platform: linux-x86
       bootjdk-platform: linux-x64
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
 
   test-macos-x64:
     name: macos-x64
@@ -284,7 +315,7 @@ jobs:
   # Remove bundles so they are not misconstrued as binary distributions from the JDK project
   remove-bundles:
     name: 'Remove bundle artifacts'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always()
     needs:
       - build-linux-x64


### PR DESCRIPTION
Clean backport from 11u-dev. This gives us more safety that GHA infra we have 11u would continue to work fast and reliably.

Additional testing:
 - [ ] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8293107](https://bugs.openjdk.org/browse/JDK-8293107): GHA: Bump to Ubuntu 22.04 (**Enhancement** - P4)
 * [JDK-8293098](https://bugs.openjdk.org/browse/JDK-8293098): GHA: Harmonize GCC version handling for host and cross builds (**Enhancement** - P4)
 * [JDK-8293361](https://bugs.openjdk.org/browse/JDK-8293361): GHA: dump config.log in case of configure failure (**Bug** - P4)
 * [JDK-8295213](https://bugs.openjdk.org/browse/JDK-8295213): Run GHA manually with user-specified make and configure arguments (**Enhancement** - P4)
 * [JDK-8295885](https://bugs.openjdk.org/browse/JDK-8295885): GHA: Bump gcc versions (**Enhancement** - P4)
 * [JDK-8313428](https://bugs.openjdk.org/browse/JDK-8313428): GHA: Bump GCC versions for July 2023 updates (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u.git pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.org/jdk11u.git pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/78.diff">https://git.openjdk.org/jdk11u/pull/78.diff</a>

</details>
