### PR TITLE
8315135: Memory leak in the native implementation of Pack200.Unpacker.unpack()

### DIFF
--- a/src/java.base/share/classes/com/sun/java/util/jar/pack/NativeUnpack.java
+++ b/src/java.base/share/classes/com/sun/java/util/jar/pack/NativeUnpack.java
@@ -61,7 +61,7 @@ class NativeUnpack {
 
     // Resets the engine and frees all resources.
     // Returns total number of bytes consumed by the engine.
-    private synchronized native long finish();
+    synchronized native long finish();
 
     // Setting state in the unpacker.
     protected  synchronized native boolean setOption(String opt, String value);

--- a/src/java.base/share/classes/com/sun/java/util/jar/pack/UnpackerImpl.java
+++ b/src/java.base/share/classes/com/sun/java/util/jar/pack/UnpackerImpl.java
@@ -116,6 +116,11 @@ public class UnpackerImpl extends TLGlobals implements Pack200.Unpacker {
                 } catch (UnsatisfiedLinkError | NoClassDefFoundError ex) {
                     // failover to java implementation
                     (new DoUnpack()).run(in0, out);
+                } finally {
+                    if (_nunp != null) {
+                       // Free up native memory and JNI handles to prevent leaks
+                       ((NativeUnpack) _nunp).finish();
+                    }
                 }
                 in0.close();
                 Utils.markJarFile(out);

--- a/src/jdk.pack/share/native/libunpack/jni.cpp
+++ b/src/jdk.pack/share/native/libunpack/jni.cpp
@@ -314,9 +314,12 @@ Java_com_sun_java_util_jar_pack_NativeUnpack_getUnusedInput(JNIEnv *env, jobject
 
 JNIEXPORT jlong JNICALL
 Java_com_sun_java_util_jar_pack_NativeUnpack_finish(JNIEnv *env, jobject pObj) {
-  unpacker* uPtr = get_unpacker(env, pObj, false);
+  // There's no need to create a new unpacker here if we don't already have one
+  // just to immediatly free it afterwards.
+  unpacker* uPtr = get_unpacker(env, pObj, /* noCreate= */ true);
   CHECK_EXCEPTION_RETURN_VALUE(uPtr, 0);
   size_t consumed = uPtr->input_consumed();
+  // free_unpacker() will set the unpacker field on 'pObj' to null
   free_unpacker(env, pObj, uPtr);
   return consumed;
 }

--- a/test/jdk/tools/pack200/UnpackMalformed.java
+++ b/test/jdk/tools/pack200/UnpackMalformed.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8315135
+ * @run main/othervm/timeout=300 -Dcom.sun.java.util.jar.pack.disable.native=false -Xmx8m UnpackMalformed
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Pack200;
+
+@SuppressWarnings("removal")
+public class UnpackMalformed {
+    public static void main(String[] args) {
+        try {
+            ByteArrayInputStream in = new ByteArrayInputStream("foobar".getBytes());
+            for (int i=0; i < 1_000; i++) {
+                try {
+                    JarOutputStream out = new JarOutputStream(new ByteArrayOutputStream());
+                    Pack200.Unpacker unpacker = Pack200.newUnpacker();
+                    unpacker.unpack(in, out);
+                } catch (IOException e) {
+                }
+            }
+        } catch (OutOfMemoryError e) {
+            System.out.println(e);
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b77c161e](https://github.com/openjdk/jdk11u-dev/commit/b77c161e7509aa3b09ebf3e6b2b1490c0667bbdc) from the [openjdk/jdk11u-dev](https://git.openjdk.org/jdk11u-dev) repository.

The commit being backported was authored by Volker Simonis on 30 Aug 2023 and was reviewed by Christoph Langer and Thomas Stuefe.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315135](https://bugs.openjdk.org/browse/JDK-8315135): Memory leak in the native implementation of Pack200.Unpacker.unpack() (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u.git pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/jdk11u.git pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/79.diff">https://git.openjdk.org/jdk11u/pull/79.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u/pull/79#issuecomment-1699469202)