### PR TITLE
8315529: [11u] Exclude some failing Z-GC tests

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -100,6 +100,7 @@ compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/codecache/stress/OverloadCompileQueueTest.java 8166554 generic-all
 compiler/codegen/Test6896617.java 8193479 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8140405 generic-all
+compiler/gcbarriers/UnsafeIntrinsicsTest.java#z 8315528 linux-x64
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
 compiler/jvmci/compilerToVM/GetResolvedJavaTypeTest.java 8158860 generic-all
 compiler/jvmci/compilerToVM/InvalidateInstalledCodeTest.java 8163894 generic-all
@@ -149,6 +150,7 @@ gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8193639 solaris-all
 gc/stress/gcbasher/TestGCBasherWithCMS.java 8272195 generic-i586
 gc/cms/TestBubbleUpRef.java  8272195 generic-i586
 gc/stress/gcold/TestGCOldWithCMS.java 8272195 generic-i586
+gc/stress/gcold/TestGCOldWithZ.java 8315531 linux-x64
 
 #############################################################################
 


### PR DESCRIPTION
There are two constantly failing Z-GC tests (in one of our/SAP's Linux x64 CI configurations).

Since Z-GC is experimental in 11 and thus probably not highly utilized, we should exclude the tests for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315529](https://bugs.openjdk.org/browse/JDK-8315529): [11u] Exclude some failing Z-GC tests (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u.git pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.org/jdk11u.git pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/80.diff">https://git.openjdk.org/jdk11u/pull/80.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u/pull/80#issuecomment-1702661729)