### PR TITLE
8331750: [11u] JDK-8259530 is not backported correctly to 11u

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
@@ -661,7 +661,7 @@ public class HtmlConfiguration extends BaseConfiguration {
                     return true;
                 }
             },
-            new Option(resources, "--legal-notices", 1) {
+            new XOption(resources, "--legal-notices", 1) {
                 @Override
                 public boolean process(String opt,  List<String> args) {
                     legalnotices = args.get(0);


### PR DESCRIPTION
This pull request ports a fix from jdk11u-dev.
I have confirmed that the fix passes the following tests:
 - test/langtools/jdk/javadoc/doclet/testLegalNotices/TestLegalNotices.java
 - All langtool tests
Could someone please review the fix?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331750](https://bugs.openjdk.org/browse/JDK-8331750) needs maintainer approval

### Issue
 * [JDK-8331750](https://bugs.openjdk.org/browse/JDK-8331750): [11u] JDK-8259530 is not backported correctly to 11u (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u.git pull/92/head:pull/92` \
`$ git checkout pull/92`

Update a local copy of the PR: \
`$ git checkout pull/92` \
`$ git pull https://git.openjdk.org/jdk11u.git pull/92/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 92`

View PR using the GUI difftool: \
`$ git pr show -t 92`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/92.diff">https://git.openjdk.org/jdk11u/pull/92.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u/pull/92#issuecomment-2143531899)