### PR TITLE
Add missing message in shenandoah else condition

### DIFF
--- a/make/autoconf/hotspot.m4
+++ b/make/autoconf/hotspot.m4
@@ -378,6 +378,7 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_FEATURES],
     fi
   else
       DISABLED_JVM_FEATURES="$DISABLED_JVM_FEATURES shenandoahgc"
+      AC_MSG_RESULT([no, shenandoah disabled])
   fi
 
   # Only enable ZGC on supported platforms


### PR DESCRIPTION
Add missing a message preventing output like:

`checking if shenandoah can be built... checking if zgc can be built... no, platform not supported`

by adding an additional explanatory message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u.git pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.org/jdk11u.git pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/97.diff">https://git.openjdk.org/jdk11u/pull/97.diff</a>

</details>
