### PR TITLE
8352097: (tz) zone.tab update missed in 2025a backport

### DIFF
--- a/make/data/tzdata/zone.tab
+++ b/make/data/tzdata/zone.tab
@@ -333,7 +333,7 @@ PF	-0900-13930	Pacific/Marquesas	Marquesas Islands
 PF	-2308-13457	Pacific/Gambier	Gambier Islands
 PG	-0930+14710	Pacific/Port_Moresby	most of Papua New Guinea
 PG	-0613+15534	Pacific/Bougainville	Bougainville
-PH	+1435+12100	Asia/Manila
+PH	+143512+1205804	Asia/Manila
 PK	+2452+06703	Asia/Karachi
 PL	+5215+02100	Europe/Warsaw
 PM	+4703-05620	America/Miquelon


### PR DESCRIPTION
As with https://github.com/openjdk/jdk21u/pull/460 & https://github.com/openjdk/jdk17u/pull/405, the [11u backport](https://git.openjdk.org/jdk11u-dev/commit/bbe28d927803d0c9286cdb1494afa9a267463dd4) of the tzdata 2025a update missed an update to zone.tab, as this was not present in the [25u commit](https://git.openjdk.org/jdk/commit/caa3c78f7837b1f561740184bd8f9cb671c467eb) on which it was originally based, due to its removal in [JDK-8166983](https://bugs.openjdk.org/browse/JDK-8166983). The change was in [the 24u commit](https://git.openjdk.org/jdk24u/commit/81252ef76899ad95197550a11c2786ccf3cf0cd2) which was applied later than the 21u one.

We should add this missing change to the existing 2025a update in 11.0.27 and consider backporting JDK-8166983 for 11.0.28 (now proposed for 24 in https://github.com/openjdk/jdk24u/pull/150).

Backport from 17u is clean. Tests pass:
~~~
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/java/text/Format                      90    90     0     0   
   jtreg:test/jdk/java/util/TimeZone                    25    25     0     0   
   jtreg:test/jdk/sun/util/calendar                      5     5     0     0   
   jtreg:test/jdk/sun/util/resources                    21    21     0     0   
   jtreg:test/jdk/java/time                            180   180     0     0   
==============================
TEST SUCCESS
~~~

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352097](https://bugs.openjdk.org/browse/JDK-8352097) needs maintainer approval

### Issue
 * [JDK-8352097](https://bugs.openjdk.org/browse/JDK-8352097): (tz) zone.tab update missed in 2025a backport (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u.git pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.org/jdk11u.git pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/101.diff">https://git.openjdk.org/jdk11u/pull/101.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u/pull/101#issuecomment-2753128441)
</details>
