### PR TITLE
8381551: DisabledCurve test fails on Windows after disabling SHA1

### DIFF
--- a/test/jdk/sun/security/ssl/CipherSuite/DisabledCurve.java
+++ b/test/jdk/sun/security/ssl/CipherSuite/DisabledCurve.java
@@ -98,8 +98,8 @@ public class DisabledCurve extends SSLSocketTemplate {
         }
         System.setProperty("jdk.sunec.disableNative", "false");
 
-        // Re-enable TLSv1 and TLSv1.1 since test depends on it.
-        SecurityUtils.removeFromDisabledTlsAlgs("TLSv1", "TLSv1.1");
+        // Re-enable TLSv1, TLSv1.1, and ecdsa_sha1 since test depends on it.
+        SecurityUtils.removeFromDisabledTlsAlgs("TLSv1", "TLSv1.1", "ecdsa_sha1");
 
         for (index = 0; index < protocols.length; index++) {
             try {

--- a/test/jdk/sun/security/ssl/CipherSuite/DisabledCurve.java
+++ b/test/jdk/sun/security/ssl/CipherSuite/DisabledCurve.java
@@ -23,12 +23,12 @@
 
 /*
  * @test
- * @bug 8246330
+ * @bug 8246330 8381551
  * @library /javax/net/ssl/templates /test/lib
- * @run main/othervm -Djdk.tls.namedGroups="sect283r1"
+ * @run main/othervm -Djdk.tls.namedGroups="secp384r1"
         DisabledCurve DISABLE_NONE PASS
- * @run main/othervm -Djdk.tls.namedGroups="sect283r1"
-        DisabledCurve sect283r1 FAIL
+ * @run main/othervm -Djdk.tls.namedGroups="secp384r1"
+        DisabledCurve secp384r1 FAIL
 */
 import java.security.Security;
 import java.util.Arrays;
@@ -51,20 +51,20 @@ public class DisabledCurve extends SSLSocketTemplate {
     @Override
     protected SSLContext createClientSSLContext() throws Exception {
         return createSSLContext(
-                new SSLContextTemplate.Cert[] {
-                        SSLContextTemplate.Cert.CA_ECDSA_SECT283R1 },
-                new SSLContextTemplate.Cert[] {
-                        SSLContextTemplate.Cert.EE_ECDSA_SECT283R1 },
+                new SSLSocketTemplate.Cert[] {
+                        SSLSocketTemplate.Cert.CA_ECDSA_SECP384R1 },
+                new SSLSocketTemplate.Cert[] {
+                        SSLSocketTemplate.Cert.EE_ECDSA_SECP384R1 },
                 getClientContextParameters());
     }
 
     @Override
     protected SSLContext createServerSSLContext() throws Exception {
         return createSSLContext(
-                new SSLContextTemplate.Cert[] {
-                        SSLContextTemplate.Cert.CA_ECDSA_SECT283R1 },
-                new SSLContextTemplate.Cert[] {
-                        SSLContextTemplate.Cert.EE_ECDSA_SECT283R1 },
+                new SSLSocketTemplate.Cert[] {
+                        SSLSocketTemplate.Cert.CA_ECDSA_SECP384R1 },
+                new SSLSocketTemplate.Cert[] {
+                        SSLSocketTemplate.Cert.EE_ECDSA_SECP384R1 },
                 getServerContextParameters());
     }
 
@@ -93,25 +93,26 @@ public class DisabledCurve extends SSLSocketTemplate {
     public static void main(String[] args) throws Exception {
         String expected = args[1];
         String disabledName = ("DISABLE_NONE".equals(args[0]) ? "" : args[0]);
+        boolean disabled = false;
         if (disabledName.equals("")) {
             Security.setProperty("jdk.disabled.namedCurves", "");
+        } else {
+            disabled = true;
+            Security.setProperty("jdk.certpath.disabledAlgorithms", "secp384r1");
         }
-        System.setProperty("jdk.sunec.disableNative", "false");
 
-        // Re-enable TLSv1, TLSv1.1, and ecdsa_sha1 since test depends on it.
-        SecurityUtils.removeFromDisabledTlsAlgs("TLSv1", "TLSv1.1", "ecdsa_sha1");
+        // Re-enable TLSv1 and TLSv1.1 since test depends on it.
+        SecurityUtils.removeFromDisabledTlsAlgs("TLSv1", "TLSv1.1");
 
         for (index = 0; index < protocols.length; index++) {
             try {
                 (new DisabledCurve()).run();
                 if (expected.equals("FAIL")) {
                     throw new RuntimeException(
-                            "The test case should not reach here");
+                            "Expected test to fail, but it passed");
                 }
             } catch (SSLException | IllegalStateException ssle) {
-                if ((expected.equals("FAIL"))
-                        && Security.getProperty("jdk.disabled.namedCurves")
-                                .contains(disabledName)) {
+                if (expected.equals("FAIL") && disabled) {
                     System.out.println(
                             "Expected exception was thrown: TEST PASSED");
                 } else {


### PR DESCRIPTION
This patch mimics changes to DisabledCurve.java from commit 0b83fc01 in
the jdk16u repo. By replacing `sect283r1` with `secp384r1`, we use
SHA384 with ECDSA, thus avoiding SHA1 with ECDSA altogether.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8381551](https://bugs.openjdk.org/browse/JDK-8381551) needs maintainer approval

### Issue
 * [JDK-8381551](https://bugs.openjdk.org/browse/JDK-8381551): DisabledCurve test fails on Windows after disabling SHA1 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u.git pull/118/head:pull/118` \
`$ git checkout pull/118`

Update a local copy of the PR: \
`$ git checkout pull/118` \
`$ git pull https://git.openjdk.org/jdk11u.git pull/118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 118`

View PR using the GUI difftool: \
`$ git pr show -t 118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/118.diff">https://git.openjdk.org/jdk11u/pull/118.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u/pull/118#issuecomment-4423804968)
</details>
