### PR TITLE
8384158: GHA: Downgrade Windows GHA runners to windows-2022 temporarily

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,6 +31,9 @@ on:
       platform:
         required: true
         type: string
+      runs-on:
+        required: true
+        type: string
       extra-conf-options:
         required: false
         type: string
@@ -63,7 +66,7 @@ env:
 jobs:
   build-windows:
     name: build
-    runs-on: windows-2025
+    runs-on: ${{ inputs.runs-on }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -246,6 +246,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
+      runs-on: windows-2022
       msvc-toolset-version: '14.44'
       msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
@@ -258,6 +259,7 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
+      runs-on: windows-2022
       msvc-toolset-version: '14.44'
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
@@ -308,5 +310,4 @@ jobs:
     with:
       platform: windows-x64
       bootjdk-platform: windows-x64
-      runs-on: windows-2025
-
+      runs-on: windows-2022


### PR DESCRIPTION
Same as https://github.com/openjdk/jdk11u-dev/pull/3226 but for jdk11u.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8384158](https://bugs.openjdk.org/browse/JDK-8384158) needs maintainer approval

### Issue
 * [JDK-8384158](https://bugs.openjdk.org/browse/JDK-8384158): GHA: Downgrade Windows GHA runners to windows-2022 temporarily (**Bug** - P2 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u.git pull/119/head:pull/119` \
`$ git checkout pull/119`

Update a local copy of the PR: \
`$ git checkout pull/119` \
`$ git pull https://git.openjdk.org/jdk11u.git pull/119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 119`

View PR using the GUI difftool: \
`$ git pr show -t 119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/119.diff">https://git.openjdk.org/jdk11u/pull/119.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u/pull/119#issuecomment-4668089109)
</details>
