### PR TITLE
8325680: Uninitialised memory in deleteGSSCB of GSSLibStub.c:179

### DIFF
--- a/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
+++ b/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -197,7 +197,10 @@ gss_channel_bindings_t newGSSCB(JNIEnv *env, jobject jcb) {
     return GSS_C_NO_CHANNEL_BINDINGS;
   }
 
-  cb = malloc(sizeof(struct gss_channel_bindings_struct));
+  // initialize cb as zeroes to avoid uninitialized pointer being
+  // freed when deleteGSSCB is called at cleanup.
+  cb = calloc(1, sizeof(struct gss_channel_bindings_struct));
+
   if (cb == NULL) {
     throwOutOfMemoryError(env,NULL);
     return NULL;
@@ -217,9 +220,6 @@ gss_channel_bindings_t newGSSCB(JNIEnv *env, jobject jcb) {
       cb->initiator_addrtype = GSS_C_AF_NULLADDR;
       cb->acceptor_addrtype = GSS_C_AF_NULLADDR;
   }
-  // addresses needs to be initialized to empty
-  memset(&cb->initiator_address, 0, sizeof(cb->initiator_address));
-  memset(&cb->acceptor_address, 0, sizeof(cb->acceptor_address));
 
   /* set up initiator address */
   jinetAddr = (*env)->CallObjectMethod(env, jcb,


### PR DESCRIPTION
Backport of [JDK-8325680](https://bugs.openjdk.org/browse/JDK-8325680) from JDK17 that ensures that memory is properly initialized by invoking `calloc` instead of `malloc` and a posterior `memset`.

`jdk_security` continue to pass, but for for a well-known failure in `sun/security/ssl/X509KeyManager/PreferredKey.java`  because [JDK-8384815](https://bugs.openjdk.org/browse/JDK-8384815) is not yet in JDK11 (see https://github.com/openjdk/jdk11u-dev/pull/3203).

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
>> jtreg:test/jdk:jdk_security                        1371  1370     1     0 <<
==============================
TEST FAILURE
```

Backport is against `11u` and not `11u-dev` as this is labelled with `CPU26_10-critical-approved`. Also this seems to be [low risk in JDK17](https://bugs.openjdk.org/browse/JDK-8325680?focusedId=14772676&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14772676). No known follow-ups.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8325680](https://bugs.openjdk.org/browse/JDK-8325680) needs maintainer approval

### Issue
 * [JDK-8325680](https://bugs.openjdk.org/browse/JDK-8325680): Uninitialised memory in deleteGSSCB of GSSLibStub.c:179 (**Bug** - P3 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u.git pull/129/head:pull/129` \
`$ git checkout pull/129`

Update a local copy of the PR: \
`$ git checkout pull/129` \
`$ git pull https://git.openjdk.org/jdk11u.git pull/129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 129`

View PR using the GUI difftool: \
`$ git pr show -t 129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u/pull/129.diff">https://git.openjdk.org/jdk11u/pull/129.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u/pull/129#issuecomment-5631813757)
</details>
